### PR TITLE
Fix/revise add member method

### DIFF
--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/FragmentInfo.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/FragmentInfo.java
@@ -3,26 +3,18 @@ package be.vlaanderen.informatievlaanderen.ldes.server.domain.entities;
 public class FragmentInfo {
     private final String view;
     private final String shape;
-    private final String parentFragmentId;
     private final String viewShortName;
     private final String path;
     private String value;
-    private Long memberLimit;
     private Boolean immutable;
 
-    public FragmentInfo(String view, String shape, String parentFragmentId, String viewShortName, String path, String value, Long memberLimit) {
+    public FragmentInfo(String view, String shape, String viewShortName, String path, String value) {
         this.view = view;
         this.shape = shape;
-        this.parentFragmentId = parentFragmentId;
         this.viewShortName = viewShortName;
         this.path = path;
         this.value = value;
-        this.memberLimit = memberLimit;
         this.immutable = false;
-    }
-
-    public String getParentFragmentId() {
-        return parentFragmentId;
     }
 
     public String getPath() {
@@ -35,14 +27,6 @@ public class FragmentInfo {
 
     public void setValue(String value) {
         this.value = value;
-    }
-
-    public Long getMemberLimit() {
-        return memberLimit;
-    }
-
-    public void setMemberLimit(Long memberLimit) {
-        this.memberLimit = memberLimit;
     }
 
     public String getViewShortName() {

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/LdesFragment.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/LdesFragment.java
@@ -91,11 +91,19 @@ public class LdesFragment {
             statements.add(createStatement(currrentFragmentId, TREE_RELATION, treeRelationNode));
         }
         relations.forEach(treeRelation -> {
-            statements.add(createStatement(treeRelationNode, TREE_VALUE, treeRelation.getTreeValueAsStringLiteral()));
-            statements.add(createStatement(treeRelationNode, TREE_PATH, treeRelation.getTreePathAsResource()));
-            statements.add(createStatement(treeRelationNode, TREE_NODE, treeRelation.getTreeNodeAsResource()));
+            statements.add(createStatement(treeRelationNode, TREE_VALUE, createResource(treeRelation.getTreeValue())));
+            statements.add(createStatement(treeRelationNode, TREE_PATH, createResource(treeRelation.getTreePath())));
+            statements.add(createStatement(treeRelationNode, TREE_NODE, createResource(treeRelation.getTreeNode())));
             statements
-                    .add(createStatement(treeRelationNode, RDF_SYNTAX_TYPE, treeRelation.getRdfSyntaxTypeAsResource()));
+                    .add(createStatement(treeRelationNode, RDF_SYNTAX_TYPE, createResource(treeRelation.getRdfSyntaxType())));
         });
+    }
+
+    public int getCurrentNumberOfMembers(){
+        return members.size();
+    }
+
+    public void setImmutable(boolean immutable) {
+        this.fragmentInfo.setImmutable(immutable);
     }
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/LdesMember.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/LdesMember.java
@@ -1,6 +1,5 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.domain.entities;
 
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.config.LdesConfig;
 import org.apache.jena.rdf.model.*;
 
 import java.util.Objects;
@@ -30,7 +29,7 @@ public class LdesMember {
                 .orElse(null);
     }
 
-    public Statement getTreeMember() {
+    private Statement getCurrentTreeMemberStatement() {
         return memberModel
                 .listStatements(null, TREE_MEMBER, (Resource) null)
                 .nextOptional()
@@ -38,14 +37,13 @@ public class LdesMember {
     }
 
     public String getLdesMemberId() {
-        return getTreeMember().getObject().toString();
+        return getCurrentTreeMemberStatement().getObject().toString();
     }
 
-    public void resetLdesMemberView(LdesConfig ldesConfig) {
-        String viewCollection = String.format("%s/%s", ldesConfig.getHostName(), ldesConfig.getCollectionName());
-
-        Statement statement = getTreeMember();
-        memberModel.remove(statement);
-        memberModel.add(createResource(viewCollection), statement.getPredicate(), statement.getResource());
+    public void replaceTreeMemberStatement(final String hostname, final String collectionName) {
+        String viewCollection = String.format("%s/%s", hostname, collectionName);
+        Statement currentTreeMemberStatement = getCurrentTreeMemberStatement();
+        memberModel.remove(currentTreeMemberStatement);
+        memberModel.add(createResource(viewCollection), currentTreeMemberStatement.getPredicate(), currentTreeMemberStatement.getResource());
     }
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/TreeRelation.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/TreeRelation.java
@@ -1,8 +1,6 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.domain.entities;
 
-import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
+import java.util.Objects;
 
 public class TreeRelation {
     private String treePath;
@@ -10,29 +8,39 @@ public class TreeRelation {
     private String treeNode;
     private String rdfSyntaxType;
 
-    private TreeRelation() {
-    }
-
-    public TreeRelation(LdesFragment fragment, String relation, String timestampPath) {
-        this.treePath = timestampPath;
-        this.treeNode = fragment.getFragmentId();
-        this.treeValue = fragment.getFragmentInfo().getValue();
+    public TreeRelation(String treePath, String treeNode, String treeValue, String relation) {
+        this.treePath = treePath;
+        this.treeNode = treeNode;
+        this.treeValue = String.format("%s^^<http://www.w3.org/2001/XMLSchema#dateTime>",treeValue);
         this.rdfSyntaxType = relation;
     }
 
-    public Resource getTreePathAsResource() {
-        return ResourceFactory.createResource(treePath);
+    public String getTreePath() {
+        return treePath;
     }
 
-    public Literal getTreeValueAsStringLiteral() {
-        return ResourceFactory.createStringLiteral(treeValue);
+    public String getTreeValue() {
+        return treeValue;
     }
 
-    public Resource getTreeNodeAsResource() {
-        return ResourceFactory.createResource(treeNode);
+    public String getTreeNode() {
+        return treeNode;
     }
 
-    public Resource getRdfSyntaxTypeAsResource() {
-        return ResourceFactory.createResource(rdfSyntaxType);
+    public String getRdfSyntaxType() {
+        return rdfSyntaxType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TreeRelation that = (TreeRelation) o;
+        return Objects.equals(treePath, that.treePath) && Objects.equals(treeValue, that.treeValue) && Objects.equals(treeNode, that.treeNode) && Objects.equals(rdfSyntaxType, that.rdfSyntaxType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(treePath, treeValue, treeNode, rdfSyntaxType);
     }
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/TreeRelation.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/TreeRelation.java
@@ -8,6 +8,9 @@ public class TreeRelation {
     private String treeNode;
     private String rdfSyntaxType;
 
+    private TreeRelation() {
+    }
+
     public TreeRelation(String treePath, String treeNode, String treeValue, String relation) {
         this.treePath = treePath;
         this.treeNode = treeNode;

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/repositories/LdesFragmentRespository.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/repositories/LdesFragmentRespository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 public interface LdesFragmentRespository {
     LdesFragment saveFragment(LdesFragment ldesFragment);
 
-    Optional<LdesFragment> retrieveFragment(String viewShortName, String path, String value);
+    Optional<LdesFragment> retrieveFragmentByViewShortNameAndPathAndType(String viewShortName, String path, String value);
 
     Optional<LdesFragment> retrieveLastFragment(String view);
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentCreator.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentCreator.java
@@ -1,0 +1,10 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.services;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesFragment;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesMember;
+
+import java.util.Optional;
+
+public interface FragmentCreator {
+    LdesFragment createNewFragment(Optional<LdesFragment> optionalExistingLdesFragment, LdesMember firstMember);
+}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentationServiceImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentationServiceImpl.java
@@ -5,10 +5,11 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.config.ViewConfig;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.FragmentInfo;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesFragment;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesMember;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.TreeRelation;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesFragmentRespository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesMemberRepository;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 public class FragmentationServiceImpl implements FragmentationService {
@@ -18,57 +19,42 @@ public class FragmentationServiceImpl implements FragmentationService {
     private final LdesMemberRepository ldesMemberRepository;
     private final LdesFragmentRespository ldesFragmentRespository;
 
+    private final FragmentCreator fragmentCreator;
+
     public FragmentationServiceImpl(LdesConfig ldesConfig, ViewConfig viewConfig,
-                                    LdesMemberRepository ldesMemberRepository, LdesFragmentRespository ldesFragmentRespository) {
+                                    LdesMemberRepository ldesMemberRepository, LdesFragmentRespository ldesFragmentRespository, FragmentCreator fragmentCreator) {
         this.ldesConfig = ldesConfig;
         this.viewConfig = viewConfig;
         this.ldesMemberRepository = ldesMemberRepository;
         this.ldesFragmentRespository = ldesFragmentRespository;
+        this.fragmentCreator = fragmentCreator;
     }
 
     @Override
     public LdesMember addMember(LdesMember ldesMember) {
-        ldesMember.resetLdesMemberView(ldesConfig);
-        LdesFragment ldesFragment = ldesFragmentRespository.retrieveLastFragment(ldesConfig.getCollectionName())
-                .map(fragment -> {
-                    if (fragment.getMembers().size() >= fragment.getFragmentInfo().getMemberLimit()) {
-                        return makeNewFollowingFragment(fragment, ldesMember, "tree:GreaterThanRelation", "tree:LesserThanRelation");
-                    } else {
-                        fragment.addMember(ldesMember);
-                        return fragment;
-                    }
-                }).orElse(makeNewFragment(ldesMember));
+        ldesMember.replaceTreeMemberStatement(ldesConfig.getHostName(), ldesConfig.getCollectionName());
+        LdesFragment ldesFragment = retrieveLastFragmentOrCreateNewFragment(ldesMember);
+        ldesFragment.addMember(ldesMember);
         ldesFragmentRespository.saveFragment(ldesFragment);
         return ldesMemberRepository.saveLdesMember(ldesMember);
     }
 
-    private LdesFragment makeNewFollowingFragment(LdesFragment fragment,
-                                                  LdesMember ldesMember,
-                                                  String oldFragmentRelation,
-                                                  String newFragmentRelation) {
-        LdesFragment newFragment = makeNewFragment(ldesMember);
-
-        fragment.getFragmentInfo().setImmutable(true);
-        fragment.addRelation(new TreeRelation(newFragment, oldFragmentRelation, viewConfig.getTimestampPath()));
-        ldesFragmentRespository.saveFragment(fragment);
-
-        newFragment.addRelation(new TreeRelation(fragment, newFragmentRelation, viewConfig.getTimestampPath()));
-        return newFragment;
-    }
-
-    private LdesFragment makeNewFragment(LdesMember ldesMember) {
-        LdesFragment ldesFragment = LdesFragment.newFragment(ldesConfig.getHostName(),
-                new FragmentInfo(String.format("%s/%s", ldesConfig.getHostName(), ldesConfig.getCollectionName()),
-                        viewConfig.getShape(), null, ldesConfig.getCollectionName(), viewConfig.getTimestampPath(),
-                        ldesMember.getFragmentationValue(viewConfig.getTimestampPath()), viewConfig.getMemberLimit()));
-        ldesFragment.addMember(ldesMember);
-        return ldesFragment;
+    private LdesFragment retrieveLastFragmentOrCreateNewFragment(LdesMember ldesMember) {
+        return ldesFragmentRespository.retrieveLastFragment(ldesConfig.getCollectionName())
+                .map(fragment -> {
+                    if (fragment.getCurrentNumberOfMembers() >= viewConfig.getMemberLimit()) {
+                        return fragmentCreator.createNewFragment(Optional.of(fragment), ldesMember);
+                    } else {
+                        return fragment;
+                    }
+                })
+                .orElseGet(() -> fragmentCreator.createNewFragment(Optional.empty(), ldesMember));
     }
 
     @Override
     public LdesFragment getFragment(String viewShortName, String path, String value) {
-        return ldesFragmentRespository.retrieveFragment(viewShortName, path, value)
+        return ldesFragmentRespository.retrieveFragmentByViewShortNameAndPathAndType(viewShortName, path, value)
                 .orElse(LdesFragment.newFragment(ldesConfig.getHostName(),
-                        new FragmentInfo(String.format("%s/%s", ldesConfig.getHostName(), ldesConfig.getCollectionName()), viewConfig.getShape(), null, viewShortName, path, value, viewConfig.getMemberLimit())));
+                        new FragmentInfo(String.format("%s/%s", ldesConfig.getHostName(), ldesConfig.getCollectionName()), viewConfig.getShape(), viewShortName, path, value)));
     }
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreator.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreator.java
@@ -42,8 +42,8 @@ public class TimeBasedFragmentCreator implements FragmentCreator {
     }
 
     private LdesFragment createFreshFragment(LdesMember firstMember) {
-        //TODO rework this. should not remove type from timeStampPath
+        String fragmentationValue = firstMember.getFragmentationValue(viewConfig.getTimestampPath());
         return LdesFragment.newFragment(ldesConfig.getHostName(),
-                new FragmentInfo(String.format("%s/%s", ldesConfig.getHostName(), ldesConfig.getCollectionName()), viewConfig.getShape(), ldesConfig.getCollectionName(), viewConfig.getTimestampPath(), viewConfig.getTimestampPathValue()));
+                new FragmentInfo(String.format("%s/%s", ldesConfig.getHostName(), ldesConfig.getCollectionName()), viewConfig.getShape(), ldesConfig.getCollectionName(), viewConfig.getTimestampPath(), fragmentationValue));
     }
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreator.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreator.java
@@ -1,0 +1,49 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.services;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.config.LdesConfig;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.config.ViewConfig;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.FragmentInfo;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesFragment;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesMember;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.TreeRelation;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesFragmentRespository;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class TimeBasedFragmentCreator implements FragmentCreator {
+    private static final String TREE_GREATER_THAN_RELATION = "tree:GreaterThanRelation";
+    private static final String TREE_LESSER_THAN_RELATION = "tree:LesserThanRelation";
+
+    private final LdesConfig ldesConfig;
+    private final ViewConfig viewConfig;
+    private final LdesFragmentRespository ldesFragmentRespository;
+
+    public TimeBasedFragmentCreator(LdesConfig ldesConfig, ViewConfig viewConfig, LdesFragmentRespository ldesFragmentRespository) {
+        this.ldesConfig = ldesConfig;
+        this.viewConfig = viewConfig;
+        this.ldesFragmentRespository = ldesFragmentRespository;
+    }
+
+    @Override
+    public LdesFragment createNewFragment(Optional<LdesFragment> optionalLdesFragment, LdesMember firstMember) {
+        LdesFragment newFragment = createFreshFragment(firstMember);
+        optionalLdesFragment
+                .ifPresent(ldesFragment -> makeFragmentImmutableAndUpdateRelations(ldesFragment, newFragment));
+        return newFragment;
+    }
+
+    private void makeFragmentImmutableAndUpdateRelations(LdesFragment completeLdesFragment, LdesFragment newFragment) {
+        completeLdesFragment.setImmutable(true);
+        completeLdesFragment.addRelation(new TreeRelation(newFragment.getFragmentInfo().getPath(), newFragment.getFragmentId(), newFragment.getFragmentInfo().getValue(), TREE_GREATER_THAN_RELATION));
+        ldesFragmentRespository.saveFragment(completeLdesFragment);
+        newFragment.addRelation(new TreeRelation(completeLdesFragment.getFragmentInfo().getPath(), completeLdesFragment.getFragmentId(), completeLdesFragment.getFragmentInfo().getValue(), TREE_LESSER_THAN_RELATION));
+    }
+
+    private LdesFragment createFreshFragment(LdesMember firstMember) {
+        //TODO rework this. should not remove type from timeStampPath
+        return LdesFragment.newFragment(ldesConfig.getHostName(),
+                new FragmentInfo(String.format("%s/%s", ldesConfig.getHostName(), ldesConfig.getCollectionName()), viewConfig.getShape(), ldesConfig.getCollectionName(), viewConfig.getTimestampPath(), viewConfig.getTimestampPathValue()));
+    }
+}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreator.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreator.java
@@ -30,7 +30,7 @@ public class TimeBasedFragmentCreator implements FragmentCreator {
 
     @Override
     public LdesFragment createNewFragment(Optional<LdesFragment> optionalLdesFragment, LdesMember firstMember) {
-        LdesFragment newFragment = createFreshFragment(firstMember);
+        LdesFragment newFragment = createNewFragment(firstMember);
         optionalLdesFragment
                 .ifPresent(ldesFragment -> makeFragmentImmutableAndUpdateRelations(ldesFragment, newFragment));
         return newFragment;
@@ -43,7 +43,7 @@ public class TimeBasedFragmentCreator implements FragmentCreator {
         newFragment.addRelation(new TreeRelation(completeLdesFragment.getFragmentInfo().getPath(), completeLdesFragment.getFragmentId(), completeLdesFragment.getFragmentInfo().getValue(), TREE_LESSER_THAN_RELATION));
     }
 
-    private LdesFragment createFreshFragment(LdesMember firstMember) {
+    private LdesFragment createNewFragment(LdesMember firstMember) {
         String fragmentationValue = firstMember.getFragmentationValue(viewConfig.getTimestampPath());
         return LdesFragment.newFragment(ldesConfig.getHostName(),
                 new FragmentInfo(String.format("%s/%s", ldesConfig.getHostName(), ldesConfig.getCollectionName()), viewConfig.getShape(), ldesConfig.getCollectionName(), viewConfig.getTimestampPath(), fragmentationValue));

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreator.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreator.java
@@ -7,11 +7,13 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesFragme
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesMember;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.TreeRelation;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesFragmentRespository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
 @Component
+@Qualifier("default")
 public class TimeBasedFragmentCreator implements FragmentCreator {
     private static final String TREE_GREATER_THAN_RELATION = "tree:GreaterThanRelation";
     private static final String TREE_LESSER_THAN_RELATION = "tree:LesserThanRelation";

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/LdesMemberTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/LdesMemberTest.java
@@ -1,0 +1,47 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.entities;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParserBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.ResourceUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static be.vlaanderen.informatievlaanderen.ldes.server.domain.contants.RdfContants.TREE_MEMBER;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LdesMemberTest {
+
+    @Test
+    @DisplayName("Test correct replacing of TreeMember statement")
+    void when_TreeMemberStatementIsReplaced_TreeMemberStatementHasADifferentSubject() throws IOException {
+        String ldesMemberString = FileUtils.readFileToString(ResourceUtils.getFile("classpath:example-ldes-member.nq"), StandardCharsets.UTF_8);
+        LdesMember ldesMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
+        Resource expectedSubject = createResource("http://some-domain.com/ldes-collection");
+        Resource expectedObject = createResource("https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/10228622/483");
+        Property expectedPredicate = TREE_MEMBER;
+
+        ldesMember.replaceTreeMemberStatement("http://some-domain.com","ldes-collection");
+        Statement statement = ldesMember.getModel()
+                .listStatements(null, expectedPredicate, (Resource) null)
+                .nextOptional()
+                .orElseThrow(() -> new RuntimeException("No tree member found for ldes member %s".formatted(this)));
+
+        assertEquals(expectedSubject, statement.getSubject() );
+        assertEquals(expectedObject,statement.getObject());
+        assertEquals(expectedPredicate, statement.getPredicate());
+    }
+
+    private Model createModel(final String ldesMember, final Lang lang){
+        return RDFParserBuilder.create().fromString(ldesMember).lang(lang).toModel();
+    }
+
+}

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/LdesMemberTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/LdesMemberTest.java
@@ -40,6 +40,15 @@ class LdesMemberTest {
         assertEquals(expectedPredicate, statement.getPredicate());
     }
 
+    @Test
+    @DisplayName("Verify retrieving of member id from LdesMember")
+    void when_TreeMemberStatementIsAvailableInModel_LdesMemberId() throws IOException {
+        String ldesMemberString = FileUtils.readFileToString(ResourceUtils.getFile("classpath:example-ldes-member.nq"), StandardCharsets.UTF_8);
+        LdesMember ldesMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
+        String ldesMemberId = ldesMember.getLdesMemberId();
+        assertEquals("https://private-api.gipod.beta-vlaanderen.be/api/v1/mobility-hindrances/10228622/483",ldesMemberId);
+    }
+
     private Model createModel(final String ldesMember, final Lang lang){
         return RDFParserBuilder.create().fromString(ldesMember).lang(lang).toModel();
     }

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/TreeRelationTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/TreeRelationTest.java
@@ -1,0 +1,47 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.entities;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class TreeRelationTest {
+
+    @Test
+    @DisplayName("Test Equality of TreeRelations")
+    void test_EqualityOfTreeRelations() {
+        TreeRelation treeRelation = new TreeRelation("treePath", "treeNode", "treeValue", "relation");
+        TreeRelation otherTreeRelation = new TreeRelation("treePath", "treeNode", "treeValue", "relation");
+        assertEquals(treeRelation, otherTreeRelation);
+        assertEquals(treeRelation, treeRelation);
+        assertEquals(otherTreeRelation, otherTreeRelation);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TreeRelationArgumentsProvider.class)
+    void test_InequalityOfTreeRelations(Object otherTreeRelation) {
+        TreeRelation treeRelation = new TreeRelation("treePath", "treeNode", "treeValue", "relation");
+        assertNotEquals(treeRelation, otherTreeRelation);
+    }
+
+    static class TreeRelationArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(Arguments.of(new LdesMember(null)),
+                    Arguments.of(new TreeRelation("differentTreePath", "treeNode", "treeValue", "relation")),
+                    Arguments.of(new TreeRelation("treePath", "differentTreeNode", "treeValue", "relation")),
+                    Arguments.of(new TreeRelation("treePath", "treeNode", "differentTreeValue", "relation")),
+                    Arguments.of(new TreeRelation("treePath", "treeNode", "treeValue", "differentRelation")));
+        }
+    }
+
+}

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/TreeRelationTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/entities/TreeRelationTest.java
@@ -36,7 +36,9 @@ class TreeRelationTest {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-            return Stream.of(Arguments.of(new LdesMember(null)),
+            return Stream.of(
+                    Arguments.of(new LdesMember(null)),
+                    Arguments.of((Object) null),
                     Arguments.of(new TreeRelation("differentTreePath", "treeNode", "treeValue", "relation")),
                     Arguments.of(new TreeRelation("treePath", "differentTreeNode", "treeValue", "relation")),
                     Arguments.of(new TreeRelation("treePath", "treeNode", "differentTreeValue", "relation")),

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentationServiceImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentationServiceImplTest.java
@@ -42,8 +42,8 @@ class FragmentationServiceImplTest {
     private static final String PATH = "http://www.w3.org/ns/prov#generatedAtTime";
     private static final String FRAGMENTATION_VALUE_1 = "2020-12-28T09:36:09.72Z";
     private static final String FRAGMENT_ID_1 = VIEW + "?generatedAtTime=" + FRAGMENTATION_VALUE_1;
-    private static final FragmentInfo FRAGMENT_INFO = new FragmentInfo(VIEW, SHAPE, null, VIEW_SHORTNAME, PATH,
-            FRAGMENTATION_VALUE_1, 10L);
+    private static final FragmentInfo FRAGMENT_INFO = new FragmentInfo(VIEW, SHAPE, VIEW_SHORTNAME, PATH,
+            FRAGMENTATION_VALUE_1);
 
     @Autowired
     private LdesConfig ldesConfig;
@@ -89,8 +89,8 @@ class FragmentationServiceImplTest {
     @DisplayName("Adding Member when there is an incomplete fragment")
     void when_AnIncompleteFragmentExists_thenMemberIsAddedToFragment() throws IOException {
         String ldesMemberString = FileUtils.readFileToString(ResourceUtils.getFile("classpath:example-ldes-member.nq"), StandardCharsets.UTF_8);
-        LdesMember ldesMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
-        LdesMember expectedSavedMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
+        LdesMember ldesMember = new LdesMember(RdfModelConverter.fromString(ldesMemberString, Lang.NQUADS));
+        LdesMember expectedSavedMember = new LdesMember(RdfModelConverter.fromString(ldesMemberString, Lang.NQUADS));
         LdesFragment existingLdesFragment = new LdesFragment("someId", new FragmentInfo("view", "shape", "viewShortName", "Path", "Value"));
         when(ldesFragmentRespository.retrieveLastFragment(ldesConfig.getCollectionName()))
                 .thenReturn(Optional.of(existingLdesFragment));
@@ -111,8 +111,8 @@ class FragmentationServiceImplTest {
     @DisplayName("Adding Member when there is a complete fragment")
     void when_AFullFragmentExists_thenANewFragmentIsCreatedAndMemberIsAddedToNewFragment() throws IOException {
         String ldesMemberString = FileUtils.readFileToString(ResourceUtils.getFile("classpath:example-ldes-member.nq"), StandardCharsets.UTF_8);
-        LdesMember ldesMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
-        LdesMember expectedSavedMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
+        LdesMember ldesMember = new LdesMember(RdfModelConverter.fromString(ldesMemberString, Lang.NQUADS));
+        LdesMember expectedSavedMember = new LdesMember(RdfModelConverter.fromString(ldesMemberString, Lang.NQUADS));
         LdesFragment existingLdesFragment = new LdesFragment("existingFragment", new FragmentInfo("view", "shape", "viewShortName", "Path", "Value"));
         LdesFragment newFragment = new LdesFragment("someId", new FragmentInfo("view", "shape", "viewShortName", "Path", "Value"));
         IntStream.range(0, 5).forEach(index -> existingLdesFragment.addMember(new LdesMember(ModelFactory.createDefaultModel())));

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentationServiceImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentationServiceImplTest.java
@@ -9,12 +9,13 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesMember
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesFragmentRespository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesMemberRepository;
 import org.apache.commons.io.FileUtils;
-import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFParserBuilder;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,6 +26,7 @@ import org.springframework.util.ResourceUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -50,35 +52,89 @@ class FragmentationServiceImplTest {
 
     private final LdesMemberRepository ldesMemberRepository = mock(LdesMemberRepository.class);
     private final LdesFragmentRespository ldesFragmentRespository = mock(LdesFragmentRespository.class);
+
+    private final FragmentCreator fragmentCreator = mock(FragmentCreator.class);
     private FragmentationService fragmentationService;
 
     @BeforeEach
     void setUp() {
-        fragmentationService = new FragmentationServiceImpl(ldesConfig, viewConfig, ldesMemberRepository, ldesFragmentRespository);
+        fragmentationService = new FragmentationServiceImpl(ldesConfig, viewConfig, ldesMemberRepository, ldesFragmentRespository, fragmentCreator);
     }
 
     @Test
-    void when_addMember_WithOneFragmentDefined_thenReturnFragment() throws IOException {
+    @DisplayName("Adding Member when there is no existing fragment")
+    void when_NoFragmentExists_thenFragmentIsCreatedAndMemberIsAdded() throws IOException {
         String ldesMemberString = FileUtils.readFileToString(ResourceUtils.getFile("classpath:example-ldes-member.nq"), StandardCharsets.UTF_8);
         LdesMember ldesMember = new LdesMember(RdfModelConverter.fromString(ldesMemberString, Lang.NQUADS));
-
-        LdesMember expectedProcessedMember = new LdesMember(RdfModelConverter.fromString(ldesMemberString, Lang.NQUADS));
-        expectedProcessedMember.resetLdesMemberView(ldesConfig);
-
-        when(ldesFragmentRespository.retrieveFragment(ldesConfig.getCollectionName(), viewConfig.getTimestampPath(), ldesMember.getFragmentationValue(viewConfig.getTimestampPath())))
+        LdesMember expectedSavedMember = new LdesMember(RdfModelConverter.fromString(ldesMemberString, Lang.NQUADS));
+        LdesFragment createdFragment = new LdesFragment("someId", new FragmentInfo("view", "shape", "viewShortName", "Path", "Value"));
+        when(ldesFragmentRespository.retrieveLastFragment(ldesConfig.getCollectionName()))
                 .thenReturn(Optional.empty());
-        when(ldesMemberRepository.saveLdesMember(any())).thenReturn(expectedProcessedMember);
+        when(fragmentCreator.createNewFragment(Optional.empty(), ldesMember))
+                .thenReturn(createdFragment);
+        when(ldesMemberRepository.saveLdesMember(ldesMember)).thenReturn(expectedSavedMember);
 
-        fragmentationService.addMember(ldesMember);
+        LdesMember actualLdesMember = fragmentationService.addMember(ldesMember);
 
-        verify(ldesFragmentRespository, times(1)).retrieveLastFragment(ldesConfig.getCollectionName());
-        verify(ldesFragmentRespository, times(1)).saveFragment(any());
-        verify(ldesMemberRepository, times(1)).saveLdesMember(any());
+        assertEquals(expectedSavedMember, actualLdesMember);
+        InOrder inOrder = inOrder(ldesFragmentRespository, fragmentCreator, ldesMemberRepository);
+        inOrder.verify(ldesFragmentRespository, times(1)).retrieveLastFragment(ldesConfig.getCollectionName());
+        inOrder.verify(fragmentCreator, times(1)).createNewFragment(Optional.empty(), ldesMember);
+        inOrder.verify(ldesFragmentRespository, times(1)).saveFragment(createdFragment);
+        inOrder.verify(ldesMemberRepository, times(1)).saveLdesMember(ldesMember);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("Adding Member when there is an incomplete fragment")
+    void when_AnIncompleteFragmentExists_thenMemberIsAddedToFragment() throws IOException {
+        String ldesMemberString = FileUtils.readFileToString(ResourceUtils.getFile("classpath:example-ldes-member.nq"), StandardCharsets.UTF_8);
+        LdesMember ldesMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
+        LdesMember expectedSavedMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
+        LdesFragment existingLdesFragment = new LdesFragment("someId", new FragmentInfo("view", "shape", "viewShortName", "Path", "Value"));
+        when(ldesFragmentRespository.retrieveLastFragment(ldesConfig.getCollectionName()))
+                .thenReturn(Optional.of(existingLdesFragment));
+        when(ldesMemberRepository.saveLdesMember(ldesMember)).thenReturn(expectedSavedMember);
+
+        LdesMember actualLdesMember = fragmentationService.addMember(ldesMember);
+
+        assertEquals(expectedSavedMember, actualLdesMember);
+        InOrder inOrder = inOrder(ldesFragmentRespository, fragmentCreator, ldesMemberRepository);
+        inOrder.verify(ldesFragmentRespository, times(1)).retrieveLastFragment(ldesConfig.getCollectionName());
+        inOrder.verify(fragmentCreator, never()).createNewFragment(any(), any());
+        inOrder.verify(ldesFragmentRespository, times(1)).saveFragment(existingLdesFragment);
+        inOrder.verify(ldesMemberRepository, times(1)).saveLdesMember(ldesMember);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("Adding Member when there is a complete fragment")
+    void when_AFullFragmentExists_thenANewFragmentIsCreatedAndMemberIsAddedToNewFragment() throws IOException {
+        String ldesMemberString = FileUtils.readFileToString(ResourceUtils.getFile("classpath:example-ldes-member.nq"), StandardCharsets.UTF_8);
+        LdesMember ldesMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
+        LdesMember expectedSavedMember = new LdesMember(createModel(ldesMemberString, Lang.NQUADS));
+        LdesFragment existingLdesFragment = new LdesFragment("existingFragment", new FragmentInfo("view", "shape", "viewShortName", "Path", "Value"));
+        LdesFragment newFragment = new LdesFragment("someId", new FragmentInfo("view", "shape", "viewShortName", "Path", "Value"));
+        IntStream.range(0, 5).forEach(index -> existingLdesFragment.addMember(new LdesMember(ModelFactory.createDefaultModel())));
+        when(ldesFragmentRespository.retrieveLastFragment(ldesConfig.getCollectionName()))
+                .thenReturn(Optional.of(existingLdesFragment));
+        when(fragmentCreator.createNewFragment(Optional.of(existingLdesFragment), ldesMember)).thenReturn(newFragment);
+        when(ldesMemberRepository.saveLdesMember(ldesMember)).thenReturn(expectedSavedMember);
+
+        LdesMember actualLdesMember = fragmentationService.addMember(ldesMember);
+
+        assertEquals(expectedSavedMember, actualLdesMember);
+        InOrder inOrder = inOrder(ldesFragmentRespository, fragmentCreator, ldesMemberRepository);
+        inOrder.verify(ldesFragmentRespository, times(1)).retrieveLastFragment(ldesConfig.getCollectionName());
+        inOrder.verify(fragmentCreator, times(1)).createNewFragment(Optional.of(existingLdesFragment), ldesMember);
+        inOrder.verify(ldesFragmentRespository, times(1)).saveFragment(newFragment);
+        inOrder.verify(ldesMemberRepository, times(1)).saveLdesMember(ldesMember);
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
     void when_getFragment_WhenNoFragmentExists_ThenReturnEmptyFragment() {
-        when(ldesFragmentRespository.retrieveFragment(VIEW_SHORTNAME, PATH, FRAGMENTATION_VALUE_1)).thenReturn(Optional.empty());
+        when(ldesFragmentRespository.retrieveFragmentByViewShortNameAndPathAndType(VIEW_SHORTNAME, PATH, FRAGMENTATION_VALUE_1)).thenReturn(Optional.empty());
 
         LdesFragment returnedFragment = fragmentationService.getFragment(VIEW_SHORTNAME, PATH, FRAGMENTATION_VALUE_1);
 
@@ -94,7 +150,7 @@ class FragmentationServiceImplTest {
         LdesMember firstMember = new LdesMember(RdfModelConverter.fromString("_:subject1 <http://an.example/predicate1> \"object1\" .", Lang.NQUADS));
         ldesFragment.addMember(firstMember);
 
-        when(ldesFragmentRespository.retrieveFragment(VIEW_SHORTNAME, PATH, FRAGMENTATION_VALUE_1))
+        when(ldesFragmentRespository.retrieveFragmentByViewShortNameAndPathAndType(VIEW_SHORTNAME, PATH, FRAGMENTATION_VALUE_1))
                 .thenReturn(Optional.of(ldesFragment));
 
         LdesFragment returnedFragment = fragmentationService.getFragment(VIEW_SHORTNAME, PATH, FRAGMENTATION_VALUE_1);
@@ -111,7 +167,7 @@ class FragmentationServiceImplTest {
         LdesMember firstMember = new LdesMember(RdfModelConverter.fromString("_:subject1 <http://an.example/predicate1> \"object1\" .", Lang.NQUADS));
         ldesFragment.addMember(firstMember);
 
-        when(ldesFragmentRespository.retrieveFragment(VIEW_SHORTNAME, PATH, "2020-12-30T00:00:00.00Z"))
+        when(ldesFragmentRespository.retrieveFragmentByViewShortNameAndPathAndType(VIEW_SHORTNAME, PATH, "2020-12-30T00:00:00.00Z"))
                 .thenReturn(Optional.of(ldesFragment));
 
         LdesFragment returnedFragment = fragmentationService.getFragment(VIEW_SHORTNAME, PATH, "2020-12-30T00:00:00.00Z");

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentationServiceImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/FragmentationServiceImplTest.java
@@ -9,7 +9,9 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesMember
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesFragmentRespository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesMemberRepository;
 import org.apache.commons.io.FileUtils;
+import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParserBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -119,5 +121,4 @@ class FragmentationServiceImplTest {
         assertEquals(PATH, returnedFragment.getFragmentInfo().getPath());
         assertEquals(VIEW, returnedFragment.getFragmentInfo().getView());
     }
-
 }

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreatorTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/services/TimeBasedFragmentCreatorTest.java
@@ -1,0 +1,94 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.services;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.config.LdesConfig;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.config.ViewConfig;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.FragmentInfo;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesFragment;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesMember;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.TreeRelation;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.repositories.LdesFragmentRespository;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class TimeBasedFragmentCreatorTest {
+
+
+    private FragmentCreator fragmentCreator;
+    private LdesFragmentRespository ldesFragmentRespository;
+
+    @BeforeEach
+    void setUp() {
+        LdesConfig ldesConfig = createLdesConfig();
+        ViewConfig viewConfig = createViewConfig();
+        ldesFragmentRespository = mock(LdesFragmentRespository.class);
+        fragmentCreator = new TimeBasedFragmentCreator(ldesConfig, viewConfig, ldesFragmentRespository);
+    }
+
+
+    @Test
+    @DisplayName("Creating First Time-Based Fragment")
+    void when_NoFragmentExists_thenNewFragmentIsCreated() {
+        LdesMember ldesMember = new LdesMember(ModelFactory.createDefaultModel());
+
+        LdesFragment newFragment = fragmentCreator.createNewFragment(Optional.empty(), ldesMember);
+
+        verifyAssertionsOnAttributesOfFragment(newFragment);
+        assertEquals(0, newFragment.getCurrentNumberOfMembers());
+        assertEquals(0, newFragment.getRelations().size());
+        verifyNoInteractions(ldesFragmentRespository);
+    }
+
+    @Test
+    @DisplayName("Creating New Time-BasedFragment")
+    void when_AFragmentAlreadyExists_thenNewFragmentIsCreatedAndRelationsAreUpdated() {
+        LdesMember ldesMember = new LdesMember(ModelFactory.createDefaultModel());
+        LdesFragment existingLdesFragment = new LdesFragment("someId", new FragmentInfo("view", "shape", "viewShortName", "Path", "Value"));
+
+        LdesFragment newFragment = fragmentCreator.createNewFragment(Optional.of(existingLdesFragment), ldesMember);
+
+        verifyAssertionsOnAttributesOfFragment(newFragment);
+        assertEquals(0, newFragment.getCurrentNumberOfMembers());
+        verifyRelationOfFragment(newFragment, "Path",  "someId", "Value", "tree:LesserThanRelation");
+        verifyRelationOfFragment(existingLdesFragment, "http://www.w3.org/ns/prov#generatedAtTime",  "http://localhost:8080/mobility-hindrances?generatedAtTime=http://www.w3.org/ns/prov#generatedAtTime","http://www.w3.org/ns/prov#generatedAtTime", "tree:GreaterThanRelation");
+        verify(ldesFragmentRespository, times(1)).saveFragment(existingLdesFragment);
+    }
+
+    private void verifyAssertionsOnAttributesOfFragment(LdesFragment newFragment) {
+        assertEquals("http://localhost:8080/mobility-hindrances?generatedAtTime=http://www.w3.org/ns/prov#generatedAtTime", newFragment.getFragmentId());
+        assertEquals("http://localhost:8080/mobility-hindrances", newFragment.getFragmentInfo().getView());
+        assertEquals("https://private-api.gipod.test-vlaanderen.be/api/v1/ldes/mobility-hindrances/shape", newFragment.getFragmentInfo().getShape());
+        assertEquals("mobility-hindrances", newFragment.getFragmentInfo().getViewShortName());
+        assertEquals("http://www.w3.org/ns/prov#generatedAtTime", newFragment.getFragmentInfo().getPath());
+        assertEquals("http://www.w3.org/ns/prov#generatedAtTime", newFragment.getFragmentInfo().getValue());
+    }
+
+    private void verifyRelationOfFragment(LdesFragment newFragment, String expectedTreePath, String expectedTreeNode, String expectedTreeValue, String expectedRelation) {
+        assertEquals(1, newFragment.getRelations().size());
+        TreeRelation actualTreeRelationOnNewFragment = newFragment.getRelations().get(0);
+        TreeRelation expectedTreeRelationOnNewFragment = new TreeRelation(expectedTreePath, expectedTreeNode, expectedTreeValue, expectedRelation);
+        assertEquals(expectedTreeRelationOnNewFragment,actualTreeRelationOnNewFragment);
+    }
+
+    private ViewConfig createViewConfig() {
+        ViewConfig viewConfig = new ViewConfig();
+        viewConfig.setShape("https://private-api.gipod.test-vlaanderen.be/api/v1/ldes/mobility-hindrances/shape");
+        viewConfig.setMemberLimit(3L);
+        viewConfig.setTimestampPath("http://www.w3.org/ns/prov#generatedAtTime");
+        viewConfig.setVersionOfPath("http://purl.org/dc/terms/isVersionOf");
+        return viewConfig;
+    }
+
+    private LdesConfig createLdesConfig() {
+        LdesConfig ldesConfig = new LdesConfig();
+        ldesConfig.setHostName("http://localhost:8080");
+        ldesConfig.setCollectionName("mobility-hindrances");
+        return ldesConfig;
+    }
+}

--- a/ldes-server-infra-mongo/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesFragmentMongoRepository.java
+++ b/ldes-server-infra-mongo/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesFragmentMongoRepository.java
@@ -21,7 +21,7 @@ public class LdesFragmentMongoRepository implements LdesFragmentRespository {
     }
 
     @Override
-    public Optional<LdesFragment> retrieveFragment(String viewShortName, String path, String value) {
+    public Optional<LdesFragment> retrieveFragmentByViewShortNameAndPathAndType(String viewShortName, String path, String value) {
         return repository.findClosestFragments(viewShortName, path, value).findFirst()
                 .map(LdesFragmentEntity::toLdesFragment);
     }

--- a/ldes-server-infra-mongo/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesFragmentMongoRepositoryIntegrationTest.java
+++ b/ldes-server-infra-mongo/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesFragmentMongoRepositoryIntegrationTest.java
@@ -1,5 +1,6 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo;
 
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.FragmentInfo;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesFragment;
 import be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.entities.LdesFragmentEntity;
 import be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.repositories.LdesFragmentEntityRepository;
@@ -22,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableAutoConfiguration
 @ActiveProfiles("mongo-test")
 class LdesFragmentMongoRepositoryIntegrationTest {
-    private static final Long MEMBER_LIMIT = 3L;
     private static final String VIEW_SHORTNAME = "exampleData";
     private static final String VIEW = "http://localhost:8089/exampleData";
     private static final String SHAPE = "http://localhost:8089/exampleData/shape";
@@ -64,7 +64,7 @@ class LdesFragmentMongoRepositoryIntegrationTest {
     }
 
     private FragmentInfo fragmentInfo(String fragmentValue) {
-        return new FragmentInfo(VIEW, SHAPE, null, VIEW_SHORTNAME, PATH, fragmentValue, MEMBER_LIMIT);
+        return new FragmentInfo(VIEW, SHAPE, VIEW_SHORTNAME, PATH, fragmentValue);
     }
 
 

--- a/ldes-server-infra-mongo/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesFragmentMongoRepositoryIntegrationTest.java
+++ b/ldes-server-infra-mongo/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesFragmentMongoRepositoryIntegrationTest.java
@@ -1,6 +1,5 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo;
 
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.FragmentInfo;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesFragment;
 import be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.entities.LdesFragmentEntity;
 import be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.repositories.LdesFragmentEntityRepository;
@@ -45,7 +44,7 @@ class LdesFragmentMongoRepositoryIntegrationTest {
         LdesFragmentEntity ldesFragmentEntity_3 = new LdesFragmentEntity("http://server:8080/exampleData?key=1", fragmentInfo(FRAGMENT_VALUE_3), List.of(), List.of());
 
         ldesFragmentEntityRepository.saveAll(List.of(ldesFragmentEntity_1, ldesFragmentEntity_2, ldesFragmentEntity_3));
-        Optional<LdesFragment> ldesFragment = ldesFragmentMongoRepository.retrieveFragment(VIEW_SHORTNAME, PATH, "2022-03-04T18:00:00.000Z");
+        Optional<LdesFragment> ldesFragment = ldesFragmentMongoRepository.retrieveFragmentByViewShortNameAndPathAndType(VIEW_SHORTNAME, PATH, "2022-03-04T18:00:00.000Z");
 
         assertTrue(ldesFragment.isPresent());
         assertEquals(ldesFragmentEntity_2.toLdesFragment().getFragmentId(), ldesFragment.get().getFragmentId());
@@ -58,7 +57,7 @@ class LdesFragmentMongoRepositoryIntegrationTest {
         LdesFragmentEntity ldesFragmentEntity_3 = new LdesFragmentEntity("http://server:8080/exampleData?key=1", fragmentInfo(FRAGMENT_VALUE_3), List.of(), List.of());
 
         ldesFragmentEntityRepository.saveAll(List.of(ldesFragmentEntity_1, ldesFragmentEntity_2, ldesFragmentEntity_3));
-        Optional<LdesFragment> ldesFragment = ldesFragmentMongoRepository.retrieveFragment(VIEW_SHORTNAME, PATH, FRAGMENT_VALUE_2);
+        Optional<LdesFragment> ldesFragment = ldesFragmentMongoRepository.retrieveFragmentByViewShortNameAndPathAndType(VIEW_SHORTNAME, PATH, FRAGMENT_VALUE_2);
 
         assertTrue(ldesFragment.isPresent());
         assertEquals(ldesFragmentEntity_2.toLdesFragment().getFragmentId(), ldesFragment.get().getFragmentId());

--- a/ldes-server-infra-mongo/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesMemberMongoRepositoryIntegrationTest.java
+++ b/ldes-server-infra-mongo/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesMemberMongoRepositoryIntegrationTest.java
@@ -3,7 +3,9 @@ package be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.RdfModelConverter;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.entities.LdesMember;
 import be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.repositories.LdesMemberEntityRepository;
+import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParserBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,5 +41,4 @@ class LdesMemberMongoRepositoryIntegrationTest {
         assertEquals(1, ldesMemberEntityRepository.findAll().size());
         assertEquals(1, ldesMemberMongoRepository.fetchLdesMembers().size());
     }
-
 }

--- a/ldes-server-infra-mongo/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesMemberMongoRepositoryTest.java
+++ b/ldes-server-infra-mongo/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/LdesMemberMongoRepositoryTest.java
@@ -60,5 +60,4 @@ class LdesMemberMongoRepositoryTest {
         assertEquals(2, actualLdesMembers.size());
         verify(ldesMemberEntityRepository, times(1)).findAll();
     }
-
 }

--- a/ldes-server-port-ingestion-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/LdesMemberIngestionControllerTest.java
+++ b/ldes-server-port-ingestion-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/LdesMemberIngestionControllerTest.java
@@ -59,5 +59,4 @@ class LdesMemberIngestionControllerTest {
         File file = new File(Objects.requireNonNull(classLoader.getResource(fileName)).toURI());
         return Files.lines(Paths.get(file.toURI())).collect(Collectors.joining("\n"));
     }
-
 }

--- a/ldes-server-port-publication-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/LdesFragmentControllerTest.java
+++ b/ldes-server-port-publication-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/LdesFragmentControllerTest.java
@@ -60,7 +60,7 @@ class LdesFragmentControllerTest {
     @ArgumentsSource(MediaTypeRdfFormatsArgumentsProvider.class)
     void when_GETRequestIsPerformed_ResponseContainsAnLDesFragment(String mediaType, Lang lang) throws Exception {
         String fragmentId = "%s/%s?generatedAtTime=%s".formatted(ldesConfig.getHostName(), ldesConfig.getCollectionName(), FRAGMENTATION_VALUE_1);
-        LdesFragment ldesFragment = new LdesFragment(fragmentId, new FragmentInfo(null, null, null, null, null, null, null));
+        LdesFragment ldesFragment = new LdesFragment(fragmentId, new FragmentInfo(null, null, null, null, null));
 
         when(fragmentationService.getFragment(ldesConfig.getCollectionName(), viewConfig.getTimestampPath(), FRAGMENTATION_VALUE_1)).thenReturn(ldesFragment);
 


### PR DESCRIPTION
This is mainly an effort in restructuring the code. I haven't fixed existing issues to keep the PR size limited.
Note that at this moment there are still the following issues:

- The new fragment we create is not based on the LDESMember
- When there are more members with the same value for path, we will create a new fragment with the same Id (error)
- When using the parent url (http://localhost:8080/mobility-hindrances) the first fragment is not shown.
