### PR TITLE
Fix: add MalformedMemberIdException

### DIFF
--- a/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/converters/LdesMemberConverter.java
+++ b/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/converters/LdesMemberConverter.java
@@ -2,6 +2,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.ingestion.rest.converters
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.config.LdesConfig;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
+import be.vlaanderen.informatievlaanderen.ldes.server.ingestion.rest.exceptions.MalformedMemberIdException;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
@@ -61,7 +62,7 @@ public class LdesMemberConverter extends AbstractHttpMessageConverter<Member> {
 				.listStatements(null, RDF_SYNTAX_TYPE, createResource(ldesConfig.getMemberType()))
 				.nextOptional()
 				.map(statement -> statement.getSubject().toString())
-				.orElse(null);
+				.orElseThrow(MalformedMemberIdException::new);
 	}
 
 	@Override

--- a/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/exceptions/MalformedMemberIdException.java
+++ b/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/exceptions/MalformedMemberIdException.java
@@ -2,13 +2,13 @@ package be.vlaanderen.informatievlaanderen.ldes.server.ingestion.rest.exceptions
 
 public class MalformedMemberIdException extends RuntimeException {
 
-    public MalformedMemberIdException(){
-        super();
-    }
+	public MalformedMemberIdException() {
+		super();
+	}
 
-    @Override
-    public String getMessage() {
-        return "Member id could not be extracted. MemberType could not be found in listStatements.";
-    }
+	@Override
+	public String getMessage() {
+		return "Member id could not be extracted. MemberType could not be found in listStatements.";
+	}
 
 }

--- a/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/exceptions/MalformedMemberIdException.java
+++ b/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/exceptions/MalformedMemberIdException.java
@@ -1,0 +1,14 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.ingestion.rest.exceptions;
+
+public class MalformedMemberIdException extends RuntimeException {
+
+    public MalformedMemberIdException(){
+        super();
+    }
+
+    @Override
+    public String getMessage() {
+        return "Member id could not be extracted. MemberType could not be found in listStatements.";
+    }
+
+}


### PR DESCRIPTION
Throw MalformedMemberIdException when MemberType could not be found in listStatements