### PR TITLE
Fix: concurrent modification operation on geospatial fragmentation

### DIFF
--- a/ldes-fragmentisers/ldes-fragmentisers-geospatial/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/geospatial/GeospatialFragmentationStrategy.java
+++ b/ldes-fragmentisers/ldes-fragmentisers-geospatial/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/geospatial/GeospatialFragmentationStrategy.java
@@ -10,6 +10,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.geospatial.f
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 
+import java.util.List;
 import java.util.Set;
 
 import static be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.geospatial.constants.GeospatialConstants.FRAGMENT_KEY_TILE_ROOT;
@@ -39,10 +40,11 @@ public class GeospatialFragmentationStrategy extends FragmentationStrategyDecora
 				.start();
 		getRootTileFragment(parentFragment);
 		Set<String> tiles = geospatialBucketiser.bucketise(member);
-		tiles
+		List<LdesFragment> ldesFragments = tiles
 				.stream()
-				.map(tile -> fragmentCreator.getOrCreateTileFragment(parentFragment, tile, rootTileFragment))
-				.parallel()
+				.map(tile -> fragmentCreator.getOrCreateTileFragment(parentFragment, tile, rootTileFragment)).toList();
+		ldesFragments
+				.parallelStream()
 				.forEach(ldesFragment -> super.addMemberToFragment(ldesFragment, member,
 						geospatialFragmentationObservation));
 		geospatialFragmentationObservation.stop();


### PR DESCRIPTION
Placement of parallel() in stream doesn't matter apparently. So, collected the stream before executing the next fragmentations in parallel.
See: https://stackoverflow.com/questions/67620445/does-it-matter-where-to-place-parallel-call-in-the-stream-pipeline