### PR TITLE
Feature: Shacl Collection

### DIFF
--- a/ldes-fragmentisers/ldes-fragmentisers-pagination/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/pagination/PaginationStrategyTest.java
+++ b/ldes-fragmentisers/ldes-fragmentisers-pagination/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/pagination/PaginationStrategyTest.java
@@ -6,7 +6,6 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.servic
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragmentrequest.valueobjects.FragmentPair;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
-import be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.pagination.PaginationStrategy;
 import be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.pagination.services.OpenPageProvider;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;

--- a/ldes-fragmentisers/ldes-fragmentisers-pagination/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/pagination/PaginationStrategyWrapperTest.java
+++ b/ldes-fragmentisers/ldes-fragmentisers-pagination/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/pagination/PaginationStrategyWrapperTest.java
@@ -2,8 +2,6 @@ package be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.pagination;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.services.FragmentationStrategy;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ConfigProperties;
-import be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.pagination.PaginationStrategy;
-import be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.pagination.PaginationStrategyWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;

--- a/ldes-fragmentisers/ldes-fragmentisers-pagination/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/pagination/services/OpenPageProviderTest.java
+++ b/ldes-fragmentisers/ldes-fragmentisers-pagination/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/pagination/services/OpenPageProviderTest.java
@@ -4,8 +4,6 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.entiti
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.repository.LdesFragmentRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragmentrequest.valueobjects.FragmentPair;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
-import be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.pagination.services.OpenPageProvider;
-import be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.pagination.services.PageCreator;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/ldes-fragmentisers/ldes-fragmentisers-pagination/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/pagination/services/PageCreatorTest.java
+++ b/ldes-fragmentisers/ldes-fragmentisers-pagination/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/fragmentisers/pagination/services/PageCreatorTest.java
@@ -4,7 +4,6 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.entiti
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.repository.LdesFragmentRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragmentrequest.valueobjects.FragmentPair;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
-import be.vlaanderen.informatievlaanderen.ldes.server.fragmentisers.pagination.services.PageCreator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/constants/RdfConstants.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/constants/RdfConstants.java
@@ -18,6 +18,7 @@ public class RdfConstants {
 	public static final Property TREE_MEMBER = createProperty(TREE, "member");
 	public static final String TREE_NODE_RESOURCE = TREE + "Node";
 	public static final String LDES = "https://w3id.org/ldes#";
+	public static final String SHACL = "http://www.w3.org/ns/shacl#";
 	public static final Property LDES_VERSION_OF = createProperty(LDES, "versionOfPath");
 	public static final Property LDES_TIMESTAMP_PATH = createProperty(LDES, "timestampPath");
 	public static final String RDF_SYNTAX = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
@@ -36,6 +37,6 @@ public class RdfConstants {
 	public static final String VIEW = LDES + "view";
 	public static final String VIEW_TYPE = LDES + "View";
 	public static final String SHAPE = TREE + "shape";
-	public static final String NODE_SHAPE_TYPE = TREE + "NodeShape";
+	public static final String NODE_SHAPE_TYPE = SHACL + "NodeShape";
 	public static final String EVENT_STREAM_TYPE = LDES + "EventStream";
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesconfig/services/LdesConfigModelServiceImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesconfig/services/LdesConfigModelServiceImpl.java
@@ -49,7 +49,8 @@ public class LdesConfigModelServiceImpl implements LdesConfigModelService {
 
 	@Override
 	public List<LdesConfigModel> retrieveAllShapes() {
-		return retrieveAllConfigModels().stream()
+		return retrieveAllConfigModels()
+				.stream()
 				.map(configModel -> retrieveShape(configModel.getId()))
 				.toList();
 	}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/shacl/InMemoryShaclCollection.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/shacl/InMemoryShaclCollection.java
@@ -21,13 +21,6 @@ public class InMemoryShaclCollection implements ShaclCollection {
 		this.ldesConfigModelService = ldesConfigModelService;
 	}
 
-	@PostConstruct
-	private void initShapeConfig() {
-		ldesConfigModelService
-				.retrieveAllShapes()
-				.forEach(ldesConfigModel -> shapes.put(ldesConfigModel.getId(), ldesConfigModel.getModel()));
-	}
-
 	@EventListener
 	public void handleShaclChangedEvent(ShaclChangedEvent event) {
 		shapes.put(event.getCollectionName(), event.getShacl());
@@ -38,5 +31,12 @@ public class InMemoryShaclCollection implements ShaclCollection {
 	@Override
 	public LdesConfigModel retrieveShape(String collectionName) {
 		return new LdesConfigModel(collectionName, shapes.get(collectionName));
+	}
+
+	@PostConstruct
+	private void initShapes() {
+		ldesConfigModelService
+				.retrieveAllShapes()
+				.forEach(ldesConfigModel -> shapes.put(ldesConfigModel.getId(), ldesConfigModel.getModel()));
 	}
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/shacl/InMemoryShaclCollection.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/shacl/InMemoryShaclCollection.java
@@ -1,0 +1,42 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.shacl;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.ShaclChangedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesconfig.services.LdesConfigModelService;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesconfig.valueobjects.LdesConfigModel;
+import jakarta.annotation.PostConstruct;
+import org.apache.jena.rdf.model.Model;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class InMemoryShaclCollection implements ShaclCollection {
+	private final Map<String, Model> shapes;
+	private final LdesConfigModelService ldesConfigModelService;
+
+	public InMemoryShaclCollection(LdesConfigModelService ldesConfigModelService) {
+		this.shapes = new HashMap<>();
+		this.ldesConfigModelService = ldesConfigModelService;
+	}
+
+	@PostConstruct
+	private void initShapeConfig() {
+		ldesConfigModelService
+				.retrieveAllShapes()
+				.forEach(ldesConfigModel -> shapes.put(ldesConfigModel.getId(), ldesConfigModel.getModel()));
+	}
+
+	@EventListener
+	public void handleShaclChangedEvent(ShaclChangedEvent event) {
+		shapes.put(event.getCollectionName(), event.getShacl());
+		ldesConfigModelService.updateShape(event.getCollectionName(),
+				new LdesConfigModel(event.getCollectionName(), event.getShacl()));
+	}
+
+	@Override
+	public LdesConfigModel retrieveShape(String collectionName) {
+		return new LdesConfigModel(collectionName, shapes.get(collectionName));
+	}
+}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/shacl/ShaclCollection.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/shacl/ShaclCollection.java
@@ -1,0 +1,7 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.shacl;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesconfig.valueobjects.LdesConfigModel;
+
+public interface ShaclCollection {
+	LdesConfigModel retrieveShape(String collectionName);
+}

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/shacl/InMemoryShaclCollectionTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/shacl/InMemoryShaclCollectionTest.java
@@ -1,0 +1,32 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.shacl;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.ShaclChangedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesconfig.services.LdesConfigModelService;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesconfig.valueobjects.LdesConfigModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class InMemoryShaclCollectionTest {
+
+	private final LdesConfigModelService ldesConfigModelService = mock(LdesConfigModelService.class);
+	private final InMemoryShaclCollection memoryShaclCollection = new InMemoryShaclCollection(ldesConfigModelService);
+	private static final String COLLECTION_NAME = "collection";
+
+	@Test
+	void test_InsertionAndRetrieval() {
+		Model model = ModelFactory.createDefaultModel();
+
+		memoryShaclCollection.handleShaclChangedEvent(new ShaclChangedEvent(COLLECTION_NAME, model));
+
+		verify(ldesConfigModelService, times(1)).updateShape(eq(COLLECTION_NAME), any(LdesConfigModel.class));
+
+		LdesConfigModel ldesConfigModel = memoryShaclCollection.retrieveShape(COLLECTION_NAME);
+		assertEquals(COLLECTION_NAME, ldesConfigModel.getId());
+		assertTrue(model.isIsomorphicWith(ldesConfigModel.getModel()));
+	}
+
+}

--- a/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/AdminShapeRestController.java
+++ b/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/AdminShapeRestController.java
@@ -38,9 +38,10 @@ public class AdminShapeRestController {
 	}
 
 	@PutMapping("/eventstreams/{collectionName}/shape")
-	public void putShape(@PathVariable String collectionName,
+	public ResponseEntity<LdesConfigModel> putShape(@PathVariable String collectionName,
 			@RequestBody @Validated LdesConfigModel shape) {
 		eventPublisher.publishEvent(new ShaclChangedEvent(collectionName, shape.getModel()));
+		return ResponseEntity.ok(shape);
 	}
 
 }

--- a/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/AdminShapeRestController.java
+++ b/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/AdminShapeRestController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 public class AdminShapeRestController {
 
 	private final LdesConfigShaclValidator shapeValidator;
-
 	private final ApplicationEventPublisher eventPublisher;
 	private final ShaclCollection shaclCollection;
 

--- a/ldes-server-port-admin-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/AdminShapeRestControllerTest.java
+++ b/ldes-server-port-admin-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/AdminShapeRestControllerTest.java
@@ -56,7 +56,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles({ "test", "rest" })
 @ContextConfiguration(classes = { AdminShapeRestController.class,
 		AdminWebConfig.class, AdminRestResponseEntityExceptionHandler.class })
-@Import(AdminShapeRestControllerTest.MockitoPublisherConfiguration.class)
+@Import(AdminShapeRestControllerTest.AdminShapeRestControllerTestConfiguration.class)
 class AdminShapeRestControllerTest {
 	@MockBean
 	private LdesConfigModelService ldesConfigModelService;
@@ -162,7 +162,7 @@ class AdminShapeRestControllerTest {
 	}
 
 	@TestConfiguration
-	static class MockitoPublisherConfiguration {
+	static class AdminShapeRestControllerTestConfiguration {
 
 		@Bean
 		@Primary

--- a/ldes-server-port-admin-rest/src/test/resources/shape-1.ttl
+++ b/ldes-server-port-admin-rest/src/test/resources/shape-1.ttl
@@ -1,13 +1,43 @@
-@prefix ldes: <https://w3id.org/ldes#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix tree: <https://w3id.org/tree#>.
-@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix :      <http://example.com/restaurant#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 
 
-[] a tree:NodeShape ;
-    ldes:example dcterms:example ;
-    ldes:versionOfPath dcterms:example ;
-    tree:shape [
-        sh:closed "true";
-        a sh:NodeShape ;
-    ] .
+:MenuItemShape
+	a sh:NodeShape ;
+	sh:targetClass :MenuItem ;
+	sh:property [
+        	sh:path      :name ;
+	        sh:datatype  xsd:string ;
+	        sh:minCount  1 ;
+	        sh:maxCount  1 ;
+	];
+	sh:property [
+            sh:path      :category ;
+            sh:nodeKind  sh:IRI ;
+            sh:maxCount  1 ;
+            sh:in (:mainDish :starter :dessert) ;
+    ];
+	sh:property [
+	        sh:path      :price ;
+	        sh:datatype  xsd:decimal ;
+	        sh:minCount  1 ;
+	        sh:maxCount  1 ;
+	];
+	sh:property [
+        	sh:path      :ingredients ;
+	        sh:datatype  xsd:string ;
+	        sh:minCount  1 ;
+	] .
+
+:mainDish a skos:Concept ;
+    skos:prefLabel "Main Dish" .
+
+:starter a skos:Concept ;
+    skos:prefLabel "Starter" .
+
+:dessert a skos:Concept ;
+    skos:prefLabel "Dessert" .

--- a/ldes-server-port-admin-rest/src/test/resources/shape-without-type.ttl
+++ b/ldes-server-port-admin-rest/src/test/resources/shape-without-type.ttl
@@ -1,13 +1,42 @@
-@prefix ldes: <https://w3id.org/ldes#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix tree: <https://w3id.org/tree#>.
-@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix :      <http://example.com/restaurant#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 
 
-[]
-    ldes:example dcterms:example ;
-    ldes:versionOfPath dcterms:example ;
-    tree:shape [
-        sh:closed "true";
-        a sh:NodeShape ;
-    ] .
+:MenuItemShape
+	sh:targetClass :MenuItem ;
+	sh:property [
+        	sh:path      :name ;
+	        sh:datatype  xsd:string ;
+	        sh:minCount  1 ;
+	        sh:maxCount  1 ;
+	];
+	sh:property [
+            sh:path      :category ;
+            sh:nodeKind  sh:IRI ;
+            sh:maxCount  1 ;
+            sh:in (:mainDish :starter :dessert) ;
+    ];
+	sh:property [
+	        sh:path      :price ;
+	        sh:datatype  xsd:decimal ;
+	        sh:minCount  1 ;
+	        sh:maxCount  1 ;
+	];
+	sh:property [
+        	sh:path      :ingredients ;
+	        sh:datatype  xsd:string ;
+	        sh:minCount  1 ;
+	] .
+
+:mainDish a skos:Concept ;
+    skos:prefLabel "Main Dish" .
+
+:starter a skos:Concept ;
+    skos:prefLabel "Starter" .
+
+:dessert a skos:Concept ;
+    skos:prefLabel "Dessert" .

--- a/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/LdesMemberIngestionController.java
+++ b/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/LdesMemberIngestionController.java
@@ -34,6 +34,7 @@ public class LdesMemberIngestionController {
 
 	private void validateMember(Member member, String collectionName) {
 		Model shape = shaclCollection.retrieveShape(collectionName).getModel();
-		new LdesShaclValidator(shape, appConfig.getLdesConfig(collectionName)).validate(member);
+		if (shape != null)
+			new LdesShaclValidator(shape, appConfig.getLdesConfig(collectionName)).validate(member);
 	}
 }

--- a/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/LdesMemberIngestionController.java
+++ b/ldes-server-port-ingestion-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/LdesMemberIngestionController.java
@@ -34,7 +34,8 @@ public class LdesMemberIngestionController {
 
 	private void validateMember(Member member, String collectionName) {
 		Model shape = shaclCollection.retrieveShape(collectionName).getModel();
-		if (shape != null)
+		if (shape != null) {
 			new LdesShaclValidator(shape, appConfig.getLdesConfig(collectionName)).validate(member);
+		}
 	}
 }

--- a/ldes-server-port-ingestion-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/MemberIngestionControllerTest.java
+++ b/ldes-server-port-ingestion-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/MemberIngestionControllerTest.java
@@ -3,6 +3,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.ingestion.rest;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.RdfModelConverter;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.ShaclChangedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesconfig.services.LdesConfigModelService;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.shacl.InMemoryShaclCollection;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.services.MemberIngestService;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.AppConfig;
@@ -47,7 +48,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest
 @ActiveProfiles("test")
 @ContextConfiguration(classes = { LdesMemberIngestionController.class,
-		IngestionWebConfig.class, AppConfig.class, IngestionRestResponseEntityExceptionHandler.class })
+		IngestionWebConfig.class, AppConfig.class, IngestionRestResponseEntityExceptionHandler.class, InMemoryShaclCollection.class})
 class MemberIngestionControllerTest {
 	private final static String RESTAURANT = "restaurant";
 

--- a/ldes-server-port-ingestion-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/MemberIngestionControllerTest.java
+++ b/ldes-server-port-ingestion-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/MemberIngestionControllerTest.java
@@ -1,9 +1,8 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.ingestion.rest;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.RdfModelConverter;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.ShaclChangedEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesconfig.services.LdesConfigModelService;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.shacl.InMemoryShaclCollection;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesconfig.valueobjects.LdesConfigModel;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.shacl.ShaclCollection;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.services.MemberIngestService;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.AppConfig;
@@ -21,8 +20,10 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -48,30 +49,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest
 @ActiveProfiles("test")
 @ContextConfiguration(classes = { LdesMemberIngestionController.class,
-		IngestionWebConfig.class, AppConfig.class, IngestionRestResponseEntityExceptionHandler.class,
-		InMemoryShaclCollection.class })
+		IngestionWebConfig.class, AppConfig.class, IngestionRestResponseEntityExceptionHandler.class })
+@Import(MemberIngestionControllerTest.MemberIngestionControllerTestConfiguration.class)
 class MemberIngestionControllerTest {
-	private final static String RESTAURANT = "restaurant";
-
-	@Autowired
-	private ApplicationEventPublisher publisher;
-
+	private final static String RESTAURANT_COLLECTION = "restaurant";
+	private final static String MOBILITY_HINDRANCES_COLLECTION = "mobility-hindrances";
 	@Autowired
 	private MockMvc mockMvc;
-
 	@MockBean
 	private MemberIngestService memberIngestService;
-
-	@MockBean
-	private LdesConfigModelService ldesConfigModelService;
-
 	@Autowired
 	private AppConfig appConfig;
+	@Autowired
+	private ShaclCollection shaclCollection;
 
 	@ParameterizedTest(name = "Ingest an LDES member in the REST service usingContentType {0}")
 	@ArgumentsSource(ContentTypeRdfFormatLangArgumentsProvider.class)
 	void when_POSTRequestIsPerformed_LDesMemberIsSaved(String contentType, Lang rdfFormat) throws Exception {
 		String ldesMemberString = readLdesMemberDataFromFile("example-ldes-member.nq", rdfFormat);
+		when(shaclCollection.retrieveShape(MOBILITY_HINDRANCES_COLLECTION))
+				.thenReturn(new LdesConfigModel(MOBILITY_HINDRANCES_COLLECTION, null));
 
 		mockMvc.perform(post("/mobility-hindrances").contentType(contentType).content(ldesMemberString))
 				.andDo(print()).andExpect(status().isOk());
@@ -94,6 +91,8 @@ class MemberIngestionControllerTest {
 	void when_POSTRequestIsPerformed_LDesMemberIsSavedWithoutVersionOfAndTimestamp() throws Exception {
 		String ldesMemberString = readLdesMemberDataFromFile("example-ldes-member-without-version-of-timestamp.nq",
 				Lang.NQUADS);
+		when(shaclCollection.retrieveShape(MOBILITY_HINDRANCES_COLLECTION))
+				.thenReturn(new LdesConfigModel(MOBILITY_HINDRANCES_COLLECTION, null));
 
 		mockMvc.perform(post("/mobility-hindrances").contentType("application/n-quads").content(ldesMemberString))
 				.andDo(print()).andExpect(status().isOk());
@@ -132,7 +131,8 @@ class MemberIngestionControllerTest {
 	void when_memberConformToShapeIsIngested_then_status200IsReturned() throws Exception {
 		Model oldShape = readModelFromFile("menu-items/example-shape-old.ttl", Lang.TURTLE);
 
-		publisher.publishEvent(new ShaclChangedEvent(RESTAURANT, oldShape));
+		when(shaclCollection.retrieveShape(RESTAURANT_COLLECTION))
+				.thenReturn(new LdesConfigModel(RESTAURANT_COLLECTION, oldShape));
 
 		String modelString = readModelStringFromFile("menu-items/example-data-old.ttl");
 
@@ -147,7 +147,8 @@ class MemberIngestionControllerTest {
 	void when_memberNotConformToShapeIsIngested_then_status400IsReturned() throws Exception {
 		Model oldShape = readModelFromFile("menu-items/example-shape-old.ttl", Lang.TURTLE);
 
-		publisher.publishEvent(new ShaclChangedEvent(RESTAURANT, oldShape));
+		when(shaclCollection.retrieveShape(RESTAURANT_COLLECTION))
+				.thenReturn(new LdesConfigModel(RESTAURANT_COLLECTION, oldShape));
 
 		String modelString = readModelStringFromFile("menu-items/example-data-new.ttl");
 
@@ -156,23 +157,6 @@ class MemberIngestionControllerTest {
 				.andExpect(status().isBadRequest());
 
 		verifyNoInteractions(memberIngestService);
-	}
-
-	@Test
-	void when_shapeIsUpdated_and_membersConformToShapeIsIngested_then_status200IsReturned() throws Exception {
-		Model oldShape = readModelFromFile("menu-items/example-shape-old.ttl", Lang.TURTLE);
-		Model newShape = readModelFromFile("menu-items/example-shape-new.ttl", Lang.TURTLE);
-
-		publisher.publishEvent(new ShaclChangedEvent(RESTAURANT, oldShape)); // init server with old shape
-		publisher.publishEvent(new ShaclChangedEvent(RESTAURANT, newShape)); // update the server with new shape
-
-		String modelString = readModelStringFromFile("menu-items/example-data-new.ttl");
-
-		mockMvc.perform(post("/restaurant").contentType("text/turtle").content(modelString))
-				.andDo(print())
-				.andExpect(status().isOk());
-
-		verify(memberIngestService).addMember(any(Member.class));
 	}
 
 	private String readLdesMemberDataFromFile(String fileName, Lang rdfFormat)
@@ -222,6 +206,15 @@ class MemberIngestionControllerTest {
 					Arguments.of("application/trix", Lang.TRIX),
 					Arguments.of("application/turtle", Lang.TURTLE),
 					Arguments.of("text/trig", Lang.TRIG));
+		}
+	}
+
+	@TestConfiguration
+	static class MemberIngestionControllerTestConfiguration {
+
+		@Bean
+		ShaclCollection shaclCollection() {
+			return mock(ShaclCollection.class);
 		}
 	}
 }

--- a/ldes-server-port-ingestion-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/MemberIngestionControllerTest.java
+++ b/ldes-server-port-ingestion-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingestion/rest/MemberIngestionControllerTest.java
@@ -48,7 +48,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest
 @ActiveProfiles("test")
 @ContextConfiguration(classes = { LdesMemberIngestionController.class,
-		IngestionWebConfig.class, AppConfig.class, IngestionRestResponseEntityExceptionHandler.class, InMemoryShaclCollection.class})
+		IngestionWebConfig.class, AppConfig.class, IngestionRestResponseEntityExceptionHandler.class,
+		InMemoryShaclCollection.class })
 class MemberIngestionControllerTest {
 	private final static String RESTAURANT = "restaurant";
 


### PR DESCRIPTION
First step in refactoring the Shacl Admin Controller by:
* Creating an in memory shacl shape collection that reflects the database collection
* redirecting all shacl update and retrieval operations towards this collection

Follow up PR will move away from the use of LdesConfigModel

The Validated issue will be taken up in an issue