### PR TITLE
Fix: Mongock Changeset 3 uses ViewName.asString

### DIFF
--- a/ldes-server-infra-mongo/mongock-changeset-3/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset3/FragmentUpdaterChange.java
+++ b/ldes-server-infra-mongo/mongock-changeset-3/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset3/FragmentUpdaterChange.java
@@ -29,7 +29,8 @@ public class FragmentUpdaterChange {
 		if (appConfig.getCollections().size() == 1) {
 			LdesConfig ldesConfig = appConfig.getCollections().get(0);
 			collection = ldesConfig.getCollectionName();
-			viewNames = ldesConfig.getViews().stream().map(ViewSpecification::getName).map(s -> "/" + s).toList();
+			viewNames = ldesConfig.getViews().stream().map(ViewSpecification::getName).map(s -> "/" + s.asString())
+					.toList();
 		} else {
 			collection = "UNDEFINED_COLLECTION";
 			viewNames = List.of("UNDEFINED_VIEWNAME");


### PR DESCRIPTION
Small Bugfix for Mongock Changeset 3 with the introduction of ViewName