### PR TITLE
Feature: Add view dynamically (part 2)

### DIFF
--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/RetentionPolicyConfig.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/RetentionPolicyConfig.java
@@ -1,8 +1,7 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy;
 
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.timebased.TimeBasedRetentionPolicy;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.creation.RetentionPolicyCreator;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.AppConfig;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.RetentionConfig;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -14,33 +13,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.timebased.TimebasedRetentionProperties.DURATION;
-
 @Configuration
 @EnableConfigurationProperties()
 @ComponentScan("be.vlaanderen.informatievlaanderen.ldes.server")
 public class RetentionPolicyConfig {
 
 	@Bean
-	public Map<ViewName, List<RetentionPolicy>> retentionPolicyMap(AppConfig appConfig) {
+	public Map<ViewName, List<RetentionPolicy>> retentionPolicyMap(AppConfig appConfig,
+			RetentionPolicyCreator retentionPolicyCreator) {
 		return appConfig
 				.getCollections()
 				.stream()
 				.flatMap(ldesSpec -> ldesSpec.getViews().stream())
 				.collect(Collectors.toMap(ViewSpecification::getName,
-						viewSpecification -> viewSpecification
-								.getRetentionConfigs()
-								.stream()
-								.map(this::getRetentionPolicy)
-								.toList()));
-	}
-
-	private RetentionPolicy getRetentionPolicy(RetentionConfig retentionConfig) {
-		if ("timebased".equals(retentionConfig.getName())) {
-			return new TimeBasedRetentionPolicy(
-					retentionConfig.getProperties().get(DURATION));
-		}
-		throw new IllegalArgumentException("Invalid retention Policy: " + retentionConfig.getName());
+						retentionPolicyCreator::createRetentionPolicyListForView));
 	}
 
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/creation/RetentionPolicyCreator.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/creation/RetentionPolicyCreator.java
@@ -1,0 +1,10 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.creation;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.RetentionPolicy;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
+
+import java.util.List;
+
+public interface RetentionPolicyCreator {
+	List<RetentionPolicy> createRetentionPolicyListForView(ViewSpecification viewSpecification);
+}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/creation/RetentionPolicyCreatorImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/creation/RetentionPolicyCreatorImpl.java
@@ -1,0 +1,32 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.creation;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.RetentionPolicy;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.timebased.TimeBasedRetentionPolicy;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.RetentionConfig;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
+
+import java.util.List;
+
+import static be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.timebased.TimebasedRetentionProperties.DURATION;
+
+public class RetentionPolicyCreatorImpl implements RetentionPolicyCreator {
+
+	@Override
+	public List<RetentionPolicy> createRetentionPolicyListForView(ViewSpecification viewSpecification) {
+		return viewSpecification
+				.getRetentionConfigs()
+				.stream()
+				.map(this::getRetentionPolicy)
+				.toList();
+	}
+
+	private RetentionPolicy getRetentionPolicy(RetentionConfig retentionConfig) {
+		// TODO update so that multiple retention policies can easily be incorporated
+		if ("timebased".equals(retentionConfig.getName())) {
+			return new TimeBasedRetentionPolicy(
+					retentionConfig.getProperties().get(DURATION));
+		}
+		throw new IllegalArgumentException("Invalid retention Policy: " + retentionConfig.getName());
+	}
+
+}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/creation/RetentionPolicyCreatorImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/creation/RetentionPolicyCreatorImpl.java
@@ -11,6 +11,8 @@ import static be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retenti
 
 public class RetentionPolicyCreatorImpl implements RetentionPolicyCreator {
 
+	public static final String TIMEBASED_RETENTION_POLICY = "timebased";
+
 	@Override
 	public List<RetentionPolicy> createRetentionPolicyListForView(ViewSpecification viewSpecification) {
 		return viewSpecification
@@ -22,7 +24,7 @@ public class RetentionPolicyCreatorImpl implements RetentionPolicyCreator {
 
 	private RetentionPolicy getRetentionPolicy(RetentionConfig retentionConfig) {
 		// TODO update so that multiple retention policies can easily be incorporated
-		if ("timebased".equals(retentionConfig.getName())) {
+		if (TIMEBASED_RETENTION_POLICY.equals(retentionConfig.getName())) {
 			return new TimeBasedRetentionPolicy(
 					retentionConfig.getProperties().get(DURATION));
 		}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/FragmentationExecutorImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/FragmentationExecutorImpl.java
@@ -4,10 +4,13 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingR
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.entities.LdesFragment;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.repository.LdesFragmentRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.services.FragmentationStrategyCreator;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -19,13 +22,18 @@ public class FragmentationExecutorImpl implements FragmentationExecutor {
 	private final Map<ViewName, FragmentationStrategy> fragmentationStrategyMap;
 	private final Map<ViewName, LdesFragment> rootFragmentMap;
 	private final LdesFragmentRepository ldesFragmentRepository;
-
 	private final ObservationRegistry observationRegistry;
+	private final FragmentationStrategyCreator fragmentationStrategyCreator;
 
+	// TODO when the definiton of views in config is going to be deprecated, the
+	// fragmentationStrategyMap should no longer be injected.
+	// But start from an empty Map and be filled via ViewAddedEvents.
 	public FragmentationExecutorImpl(
 			@Qualifier("configured-fragmentation") Map<ViewName, FragmentationStrategy> fragmentationStrategyMap,
-			LdesFragmentRepository ldesFragmentRepository, ObservationRegistry observationRegistry) {
+			LdesFragmentRepository ldesFragmentRepository, ObservationRegistry observationRegistry,
+			FragmentationStrategyCreator fragmentationStrategyCreator) {
 		this.fragmentationStrategyMap = fragmentationStrategyMap;
+		this.fragmentationStrategyCreator = fragmentationStrategyCreator;
 		this.rootFragmentMap = new ConcurrentHashMap<>();
 		this.ldesFragmentRepository = ldesFragmentRepository;
 		this.observationRegistry = observationRegistry;
@@ -60,5 +68,11 @@ public class FragmentationExecutorImpl implements FragmentationExecutor {
 
 		rootRetrievalObservation.stop();
 		return ldesFragment;
+	}
+
+	@EventListener
+	public void handleViewAddedEvent(ViewAddedEvent event) {
+		fragmentationStrategyMap.put(event.getViewName(),
+				fragmentationStrategyCreator.createFragmentationStrategyForView(event.getViewSpecification()));
 	}
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/TreeNodeRemoverImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/TreeNodeRemoverImpl.java
@@ -1,12 +1,15 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.services;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.RetentionPolicy;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.creation.RetentionPolicyCreator;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.entities.LdesFragment;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.repository.LdesFragmentRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.repository.MemberRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.services.TreeMemberRemover;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -21,16 +24,21 @@ public class TreeNodeRemoverImpl implements TreeNodeRemover {
 	private final Map<ViewName, List<RetentionPolicy>> retentionPolicyMap;
 	private final TreeMemberRemover treeMemberRemover;
 	private final ParentUpdater parentUpdater;
+	private final RetentionPolicyCreator retentionPolicyCreator;
 
+	// TODO when the definiton of views in config is going to be deprecated, the
+	// retentionPolicyMap should no longer be injected.
+	// But start from an empty Map and be filled via ViewAddedEvents.
 	public TreeNodeRemoverImpl(LdesFragmentRepository ldesFragmentRepository,
 			MemberRepository memberRepository, Map<ViewName, List<RetentionPolicy>> retentionPolicyMap,
 			TreeMemberRemover treeMemberRemover,
-			ParentUpdater parentUpdater) {
+			ParentUpdater parentUpdater, RetentionPolicyCreator retentionPolicyCreator) {
 		this.ldesFragmentRepository = ldesFragmentRepository;
 		this.memberRepository = memberRepository;
 		this.retentionPolicyMap = retentionPolicyMap;
 		this.treeMemberRemover = treeMemberRemover;
 		this.parentUpdater = parentUpdater;
+		this.retentionPolicyCreator = retentionPolicyCreator;
 	}
 
 	@Scheduled(fixedDelay = 10000)
@@ -62,6 +70,12 @@ public class TreeNodeRemoverImpl implements TreeNodeRemover {
 								});
 					});
 				});
+	}
+
+	@EventListener
+	public void handleViewAddedEvent(ViewAddedEvent event) {
+		retentionPolicyMap.put(event.getViewName(),
+				retentionPolicyCreator.createRetentionPolicyListForView(event.getViewSpecification()));
 	}
 
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/valueobject/ViewAddedEvent.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/valueobject/ViewAddedEvent.java
@@ -1,0 +1,20 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
+
+public class ViewAddedEvent {
+	private final ViewSpecification viewSpecification;
+
+	public ViewAddedEvent(ViewSpecification viewSpecification) {
+		this.viewSpecification = viewSpecification;
+	}
+
+	public ViewName getViewName() {
+		return viewSpecification.getName();
+	}
+
+	public ViewSpecification getViewSpecification() {
+		return viewSpecification;
+	}
+}

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/RetentionPolicyConfigTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/RetentionPolicyConfigTest.java
@@ -1,5 +1,7 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy;
 
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.creation.RetentionPolicyCreator;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.creation.RetentionPolicyCreatorImpl;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.timebased.TimeBasedRetentionPolicy;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.*;
 import org.junit.jupiter.api.Test;
@@ -13,12 +15,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RetentionPolicyConfigTest {
 
+	private final RetentionPolicyCreator retentionPolicyCreator = new RetentionPolicyCreatorImpl();
+
 	@Test
 	void when_TimeBasedRetentionPolicyIsDefinedInConfig_ItIsAddedToMap() {
 		AppConfig appConfig = getLdesConfig("timebased");
 
 		RetentionPolicyConfig retentionPolicyConfig = new RetentionPolicyConfig();
-		Map<ViewName, List<RetentionPolicy>> retentionPolicyMap = retentionPolicyConfig.retentionPolicyMap(appConfig);
+		Map<ViewName, List<RetentionPolicy>> retentionPolicyMap = retentionPolicyConfig.retentionPolicyMap(appConfig,
+				retentionPolicyCreator);
 		assertEquals(1, retentionPolicyMap.size());
 		assertEquals(1, retentionPolicyMap.get(ViewName.fromString("parcels/firstView")).size());
 		assertTrue(retentionPolicyMap.get(ViewName.fromString("parcels/firstView"))
@@ -31,7 +36,7 @@ class RetentionPolicyConfigTest {
 
 		RetentionPolicyConfig retentionPolicyConfig = new RetentionPolicyConfig();
 		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> retentionPolicyConfig.retentionPolicyMap(appConfig));
+				() -> retentionPolicyConfig.retentionPolicyMap(appConfig, retentionPolicyCreator));
 		assertEquals("Invalid retention Policy: other", exception.getMessage());
 	}
 

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/FragmentationExecutorImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/FragmentationExecutorImplTest.java
@@ -4,40 +4,39 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingR
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.entities.LdesFragment;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.repository.LdesFragmentRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.services.FragmentationStrategyCreator;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class FragmentationExecutorImplTest {
 
 	private static final String COLLECTION_NAME = "collectionName";
 	private static final ViewName VIEW_NAME = new ViewName(COLLECTION_NAME, "view");
+	private final HashMap<ViewName, FragmentationStrategy> fragmentationMap = new HashMap<>();
 	private final FragmentationStrategy fragmentationStrategy = mock(FragmentationStrategy.class);
 	private final LdesFragmentRepository ldesFragmentRepository = mock(LdesFragmentRepository.class);
+	private final FragmentationStrategyCreator fragmentationStrategyCreator = mock(FragmentationStrategyCreator.class);
 	private FragmentationExecutorImpl fragmentationExecutor;
 
 	@BeforeEach
 	void setUp() {
-		fragmentationExecutor = new FragmentationExecutorImpl(Map.of(VIEW_NAME,
-				fragmentationStrategy),
-				ldesFragmentRepository, ObservationRegistry.create());
+
+		fragmentationMap.put(VIEW_NAME, fragmentationStrategy);
+		fragmentationExecutor = new FragmentationExecutorImpl(fragmentationMap,
+				ldesFragmentRepository, ObservationRegistry.create(), fragmentationStrategyCreator);
 	}
 
 	@Test
@@ -112,7 +111,18 @@ class FragmentationExecutorImplTest {
 				times(100)).addMemberToFragment(eq(ldesFragment),
 						any(), any());
 		inOrder.verifyNoMoreInteractions();
+	}
 
+	@Test
+	void when_ViewAddedEventIsReceived_FragmentationStrategyIsAddedToMap() {
+		ViewSpecification viewSpecification = new ViewSpecification(new ViewName(COLLECTION_NAME, "additonalView"),
+				List.of(), List.of());
+
+		assertFalse(fragmentationMap.containsKey(viewSpecification.getName()));
+		fragmentationExecutor.handleViewAddedEvent(new ViewAddedEvent(viewSpecification));
+
+		assertTrue(fragmentationMap.containsKey(viewSpecification.getName()));
+		verify(fragmentationStrategyCreator).createFragmentationStrategyForView(viewSpecification);
 	}
 
 }

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/InMemoryViewCollectionTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/InMemoryViewCollectionTest.java
@@ -3,6 +3,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.domain.view;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.repository.ViewRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.*;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,8 @@ import static org.mockito.Mockito.verify;
 class InMemoryViewCollectionTest {
 
 	private final ViewRepository viewRepository = mock(ViewRepository.class);
-	private final ViewCollection viewCollection = new InMemoryViewCollection(viewRepository);
+	private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+	private final ViewCollection viewCollection = new InMemoryViewCollection(viewRepository, eventPublisher);
 
 	@Test
 	void test_InsertionAndRetrieval() {

--- a/ldes-server-port-ingest-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/rest/MemberIngestControllerTest.java
+++ b/ldes-server-port-ingest-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/rest/MemberIngestControllerTest.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;


### PR DESCRIPTION
Allows to dynamically update the fragmentation process and the retention process with newly added views.
Next steps are:

- update admin api to convert a Model to a ViewSpecification (@pj-cegeka is working on this).
- removing the beans used to create fragmentation strategies and retention policies from config.

