### PR TITLE
Feature: Delete view from collection

### DIFF
--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/FragmentationExecutorImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/FragmentationExecutorImpl.java
@@ -5,6 +5,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.entiti
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.repository.LdesFragmentRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.services.FragmentationStrategyCreator;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import io.micrometer.observation.Observation;
@@ -72,7 +73,14 @@ public class FragmentationExecutorImpl implements FragmentationExecutor {
 
 	@EventListener
 	public void handleViewAddedEvent(ViewAddedEvent event) {
+		// TODO create root fragment and refragment all earlier members of collection
 		fragmentationStrategyMap.put(event.getViewName(),
 				fragmentationStrategyCreator.createFragmentationStrategyForView(event.getViewSpecification()));
+	}
+
+	@EventListener
+	public void handleViewDeletedEvent(ViewDeletedEvent event) {
+		// TODO delete all ldesfragments of view
+		fragmentationStrategyMap.remove(event.getViewName());
 	}
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/TreeNodeRemoverImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/TreeNodeRemoverImpl.java
@@ -8,6 +8,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entitie
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.repository.MemberRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.services.TreeMemberRemover;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -76,6 +77,11 @@ public class TreeNodeRemoverImpl implements TreeNodeRemover {
 	public void handleViewAddedEvent(ViewAddedEvent event) {
 		retentionPolicyMap.put(event.getViewName(),
 				retentionPolicyCreator.createRetentionPolicyListForView(event.getViewSpecification()));
+	}
+
+	@EventListener
+	public void handleViewDeletedEvent(ViewDeletedEvent event) {
+		retentionPolicyMap.remove(event.getViewName());
 	}
 
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/InMemoryViewCollection.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/InMemoryViewCollection.java
@@ -2,6 +2,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.domain.view;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.repository.ViewRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
 import jakarta.annotation.PostConstruct;
@@ -32,6 +33,14 @@ public class InMemoryViewCollection implements ViewCollection {
 		viewRepository.saveView(viewSpecification);
 		views.put(viewSpecification.getName(), viewSpecification);
 		eventPublisher.publishEvent(new ViewAddedEvent(viewSpecification));
+	}
+
+	@Override
+	public void deleteViewByViewName(ViewName viewName) {
+		viewRepository.deleteViewByViewName(viewName);
+		views.remove(viewName);
+		eventPublisher.publishEvent(new ViewDeletedEvent(viewName));
+
 	}
 
 	@PostConstruct

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/ViewCollection.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/ViewCollection.java
@@ -10,4 +10,6 @@ public interface ViewCollection {
 	Optional<ViewSpecification> getViewByViewName(ViewName viewName);
 
 	void addView(ViewSpecification viewSpecification);
+
+	void deleteViewByViewName(ViewName viewName);
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/repository/ViewRepository.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/repository/ViewRepository.java
@@ -1,5 +1,6 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.domain.view.repository;
 
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
 
 import java.util.List;
@@ -8,4 +9,6 @@ public interface ViewRepository {
 	List<ViewSpecification> retrieveAllViews();
 
 	void saveView(ViewSpecification viewSpecification);
+
+	void deleteViewByViewName(ViewName viewName);
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/service/ViewServiceImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/service/ViewServiceImpl.java
@@ -39,6 +39,6 @@ public class ViewServiceImpl implements ViewService {
 
 	@Override
 	public void deleteViewByViewName(ViewName viewName) {
-		throw new NotImplementedException();
+		viewCollection.deleteViewByViewName(viewName);
 	}
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/valueobject/ViewDeletedEvent.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/valueobject/ViewDeletedEvent.java
@@ -1,0 +1,15 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
+
+public class ViewDeletedEvent {
+	private final ViewName viewName;
+
+	public ViewDeletedEvent(ViewName viewName) {
+		this.viewName = viewName;
+	}
+
+	public ViewName getViewName() {
+		return viewName;
+	}
+}

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/FragmentationExecutorImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/FragmentationExecutorImplTest.java
@@ -5,6 +5,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.entiti
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldesfragment.repository.LdesFragmentRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.services.FragmentationStrategyCreator;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
@@ -114,7 +115,7 @@ class FragmentationExecutorImplTest {
 	}
 
 	@Test
-	void when_ViewAddedEventIsReceived_FragmentationStrategyIsAddedToMap() {
+	void test_AddingAndDeletingViews() {
 		ViewSpecification viewSpecification = new ViewSpecification(new ViewName(COLLECTION_NAME, "additonalView"),
 				List.of(), List.of());
 
@@ -123,6 +124,9 @@ class FragmentationExecutorImplTest {
 
 		assertTrue(fragmentationMap.containsKey(viewSpecification.getName()));
 		verify(fragmentationStrategyCreator).createFragmentationStrategyForView(viewSpecification);
+
+		fragmentationExecutor.handleViewDeletedEvent(new ViewDeletedEvent(viewSpecification.getName()));
+		assertFalse(fragmentationMap.containsKey(viewSpecification.getName()));
 	}
 
 }

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/TreeNodeRemoverImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldesfragment/services/TreeNodeRemoverImplTest.java
@@ -10,6 +10,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entitie
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.repository.MemberRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.services.TreeMemberRemover;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +73,7 @@ class TreeNodeRemoverImplTest {
 	}
 
 	@Test
-	void when_ViewAddedEventIsReceived_RetentionPolicyMapIsUpdated() {
+	void test_AddingAndDeletingViews() {
 		ViewSpecification viewSpecification = new ViewSpecification(new ViewName("collection", "additonalView"),
 				List.of(), List.of());
 
@@ -80,6 +81,8 @@ class TreeNodeRemoverImplTest {
 		treeNodeRemover.handleViewAddedEvent(new ViewAddedEvent(viewSpecification));
 
 		assertTrue(retentionPolicyMap.containsKey(viewSpecification.getName()));
+		treeNodeRemover.handleViewDeletedEvent(new ViewDeletedEvent(viewSpecification.getName()));
+		assertFalse(retentionPolicyMap.containsKey(viewSpecification.getName()));
 	}
 
 	private LdesFragment notReadyToDeleteFragment() {

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/InMemoryViewCollectionTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/InMemoryViewCollectionTest.java
@@ -37,6 +37,22 @@ class InMemoryViewCollectionTest {
 		assertEquals(view, retrievedView.get());
 	}
 
+	@Test
+	void test_deletion() {
+		ViewSpecification view = new ViewSpecification(new ViewName("collection", "view"),
+				getRetentionPolicies(),
+				getFragmentations());
+		viewCollection.addView(view);
+		Optional<ViewSpecification> retrievedView = viewCollection.getViewByViewName(view.getName());
+		assertTrue(retrievedView.isPresent());
+
+		viewCollection.deleteViewByViewName(view.getName());
+
+		verify(viewRepository).deleteViewByViewName(view.getName());
+		retrievedView = viewCollection.getViewByViewName(view.getName());
+		assertFalse(retrievedView.isPresent());
+	}
+
 	private List<FragmentationConfig> getFragmentations() {
 		FragmentationConfig fragmentationConfig = new FragmentationConfig();
 		fragmentationConfig.setName("GeoSpatial");

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/service/ViewServiceImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/service/ViewServiceImplTest.java
@@ -49,4 +49,18 @@ class ViewServiceImplTest {
             verifyNoMoreInteractions(viewCollection);
         }
 	}
+
+	@Nested
+	class DeleteView {
+		private final ViewName viewName = new ViewName("collection", "view");
+
+		@Test
+		void when_ViewDoesNotExist_ViewIsAdded() {
+			viewService.deleteViewByViewName(viewName);
+
+			InOrder inOrder = inOrder(viewCollection);
+			inOrder.verify(viewCollection).deleteViewByViewName(viewName);
+			inOrder.verifyNoMoreInteractions();
+		}
+	}
 }

--- a/ldes-server-infra-mongo/mongo-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/view/ViewMongoRepository.java
+++ b/ldes-server-infra-mongo/mongo-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/view/ViewMongoRepository.java
@@ -1,6 +1,7 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.view;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.repository.ViewRepository;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
 import be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.view.repository.ViewEntityRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.view.service.ViewEntityConverter;
@@ -28,5 +29,10 @@ public class ViewMongoRepository implements ViewRepository {
 	@Override
 	public void saveView(ViewSpecification viewSpecification) {
 		repository.save(converter.fromView(viewSpecification));
+	}
+
+	@Override
+	public void deleteViewByViewName(ViewName viewName) {
+		repository.deleteById(viewName.asString());
 	}
 }

--- a/ldes-server-infra-mongo/mongo-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/view/ViewMongoRepositoryTest.java
+++ b/ldes-server-infra-mongo/mongo-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/view/ViewMongoRepositoryTest.java
@@ -53,4 +53,13 @@ class ViewMongoRepositoryTest {
 		verify(viewEntityRepository).save(any(ViewEntity.class));
 	}
 
+	@Test
+	void test_deleteingOfView() {
+		final ViewName viewName = new ViewName("collection1", "view1");
+
+		repository.deleteViewByViewName(viewName);
+
+		verify(viewEntityRepository).deleteById(viewName.asString());
+	}
+
 }


### PR DESCRIPTION
Support to delete a view from a collection. This will update the viewrepository and disable fragmentation and retention processes of that view.
Next steps:
* go over all the TODO's, highest priority = side effects of adding/deleting a view such as creating a root node for that view, refragmenting all existing members of the collection, deleting all fragments of a deleted view