### PR TITLE
Feature: VSDSPUB-712: Implement Version Based Retention Policy

### DIFF
--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/RetentionPolicy.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/RetentionPolicy.java
@@ -4,5 +4,13 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entitie
 
 public interface RetentionPolicy {
 
+	/**
+	 * When a Member matches the RetentionPolicy it's a candidate for removal from a
+	 * View and eventually from the MemberRepository
+	 *
+	 * @param member
+	 *            provided Member
+	 * @return true when the Member matches the RetentionPolicy
+	 */
 	boolean matchesPolicy(Member member);
 }

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/versionbased/ReverseTimeStampComparator.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/versionbased/ReverseTimeStampComparator.java
@@ -1,0 +1,12 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.versionbased;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
+
+import java.util.Comparator;
+
+public class ReverseTimeStampComparator implements Comparator<Member> {
+	@Override
+	public int compare(Member o1, Member o2) {
+		return o2.getTimestamp().compareTo(o1.getTimestamp());
+	}
+}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/versionbased/VersionBasedRetentionPolicy.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/versionbased/VersionBasedRetentionPolicy.java
@@ -1,0 +1,46 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.versionbased;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.RetentionPolicy;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.repository.MemberRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * The VersionBasedRetentionPolicy has two arguments numberOfMembersToKeep and a
+ * memberRepository.
+ * <p>
+ * When testing a Member, it first verifies that both the timestamp and
+ * versionOf attribute are set on the member.
+ * If not, it returns false.
+ * Otherwise, it will retrieve all members that have the same versionOf
+ * attribute.
+ * It will sort these members according to the timestamp attribute.
+ * It returns false for the N (numberOfMembersToKeep) most recent members and
+ * true for the other members.
+ */
+public class VersionBasedRetentionPolicy implements RetentionPolicy {
+	private final int numberOfMembersToKeep;
+	private final MemberRepository memberRepository;
+
+	public VersionBasedRetentionPolicy(int numberOfMembersToKeep, MemberRepository memberRepository) {
+		this.numberOfMembersToKeep = numberOfMembersToKeep;
+		this.memberRepository = memberRepository;
+	}
+
+	@Override
+	public boolean matchesPolicy(Member member) {
+		String versionOf = member.getVersionOf();
+		LocalDateTime timestamp = member.getTimestamp();
+		if (versionOf != null && timestamp != null) {
+			List<Member> membersOfVersion = memberRepository.getMembersOfVersion(versionOf);
+			List<Member> sortedMembersByTimestampDescending = membersOfVersion.stream()
+					.sorted(new ReverseTimeStampComparator())
+					.toList();
+			List<Member> membersToKeep = sortedMembersByTimestampDescending.subList(0, numberOfMembersToKeep);
+			return !membersToKeep.contains(member);
+		}
+		return false;
+	}
+}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/tree/member/repository/MemberRepository.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/tree/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.reposi
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -27,4 +28,6 @@ public interface MemberRepository {
 	void removeMemberReference(String memberId, String fragmentId);
 
 	Stream<Member> getMemberStreamOfCollection(String collectionName);
+
+	List<Member> getMembersOfVersion(String versionOf);
 }

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/versionbased/VersionBasedRetentionPolicyTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/ldes/retentionpolicy/versionbased/VersionBasedRetentionPolicyTest.java
@@ -1,0 +1,68 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.domain.ldes.retentionpolicy.versionbased;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.entities.Member;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.tree.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VersionBasedRetentionPolicyTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	private VersionBasedRetentionPolicy versionBasedRetentionPolicy;
+
+	@BeforeEach
+	void setUp() {
+		versionBasedRetentionPolicy = new VersionBasedRetentionPolicy(2,
+				memberRepository);
+	}
+
+	@Test
+	void when_TimestampIsNull_then_VersionBasedRetentionPolicyReturnsFalse() {
+		Member member = getMember("id", "1", null);
+
+		boolean memberMatchesPolicy = versionBasedRetentionPolicy.matchesPolicy(member);
+
+		assertFalse(memberMatchesPolicy);
+	}
+
+	@Test
+	void when_VersionOfIsNull_then_VersionBasedRetentionPolicyReturnsFalse() {
+		Member member = getMember("id", null, LocalDateTime.now());
+
+		boolean memberMatchesPolicy = versionBasedRetentionPolicy.matchesPolicy(member);
+
+		assertFalse(memberMatchesPolicy);
+	}
+
+	@Test
+	void when_MultipleVersionsOfAResource_then_VersionBasedRetentionPolicyReturnsTrueForNMostRecentMembers() {
+		Member member1 = getMember("1/1", "1", LocalDateTime.now().plusMinutes(1));
+		Member member2 = getMember("1/2", "1", LocalDateTime.now().plusMinutes(2));
+		Member member3 = getMember("1/3", "1", LocalDateTime.now().plusMinutes(3));
+		Member member4 = getMember("1/4", "1", LocalDateTime.now().plusMinutes(4));
+
+		when(memberRepository.getMembersOfVersion("1")).thenReturn(List.of(member2, member3, member1, member4));
+
+		assertTrue(versionBasedRetentionPolicy.matchesPolicy(member1));
+		assertTrue(versionBasedRetentionPolicy.matchesPolicy(member2));
+		assertFalse(versionBasedRetentionPolicy.matchesPolicy(member3));
+		assertFalse(versionBasedRetentionPolicy.matchesPolicy(member4));
+	}
+
+	private Member getMember(String memberId, String versionOf, LocalDateTime timestamp) {
+		return new Member(memberId, null, null, versionOf, timestamp, null, null);
+	}
+
+}

--- a/ldes-server-infra-mongo/mongo-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/member/MemberMongoRepository.java
+++ b/ldes-server-infra-mongo/mongo-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/member/MemberMongoRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -18,6 +19,7 @@ public class MemberMongoRepository implements MemberRepository {
 
 	public static final String TREE_NODE_REFERENCES = "treeNodeReferences";
 	public static final String COLLECTION_NAME = "collectionName";
+	public static final String VERSION_OF = "versionOf";
 	public static final String SEQUENCE_NR = "sequenceNr";
 	private final LdesMemberEntityRepository repository;
 	private final MongoTemplate mongoTemplate;
@@ -75,6 +77,16 @@ public class MemberMongoRepository implements MemberRepository {
 		query.addCriteria(Criteria.where(COLLECTION_NAME).is(collectionName));
 		query.with(Sort.by(SEQUENCE_NR).ascending());
 		return mongoTemplate.stream(query, LdesMemberEntity.class).map(converter::toLdesMember);
+	}
+
+	@Override
+	public List<Member> getMembersOfVersion(String versionOf) {
+		Query query = new Query();
+		query.addCriteria(Criteria.where(VERSION_OF).is(versionOf));
+		return mongoTemplate
+				.stream(query, LdesMemberEntity.class)
+				.map(converter::toLdesMember)
+				.toList();
 	}
 
 	@Override

--- a/ldes-server-infra-mongo/mongo-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/MemberMongoRepositoryTest.java
+++ b/ldes-server-infra-mongo/mongo-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/MemberMongoRepositoryTest.java
@@ -115,7 +115,16 @@ class MemberMongoRepositoryTest {
 		ldesMemberMongoRepository.getMemberStreamOfCollection("collectionName");
 
 		verify(mongoTemplate, times(1)).stream(query, LdesMemberEntity.class);
+	}
 
+	@Test
+	void when_GetMembersOfVersion_then_ListOfMembersWithSameVersionOfIsReturned() {
+		Query query = new Query();
+		query.addCriteria(Criteria.where(VERSION_OF).is("versionOf"));
+
+		ldesMemberMongoRepository.getMembersOfVersion("versionOf");
+
+		verify(mongoTemplate, times(1)).stream(query, LdesMemberEntity.class);
 	}
 
 	private Model getModel() {


### PR DESCRIPTION
Provided an implementation of VersionBasedRetentionPolicy that:

- implements the RetentionPolicy interface
- returns false if the tested Member does not have the timestamp or versionOf attribute
- Otherwise: returns false for the amountOfMembersToKeep most recent members and true for the other members (which makes them a candidate for removal).

Note: There's possibly a more efficient implementation possible which only retrieves the members with the same versionOf attribute once, but I prefer this implementation because:

- it acts on the member (similar as defined in the spec)
- it fits in the current retention policy implementation
- retention is so far never a resource (memory/cpu/iops) critical process, so there's no big need for optimizations.

