### PR TITLE
Feature: Added example to Open API Admin View

### DIFF
--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/eventstream/services/EventStreamServiceImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/eventstream/services/EventStreamServiceImpl.java
@@ -97,6 +97,8 @@ public class EventStreamServiceImpl implements EventStreamService {
 				eventStreamResponse.getShacl());
 		eventStreamRepository.saveEventStream(eventStream);
 		shaclShapeService.updateShaclShape(shaclShape);
+		eventPublisher.publishEvent(new EventStreamChangedEvent(eventStream));
+		eventStreamResponse.getViews().forEach(viewService::addView);
 		if (eventStreamResponse.isDefaultViewEnabled()) {
 			viewService.addDefaultView(eventStream.getCollection());
 		}

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/service/ViewServiceImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/service/ViewServiceImpl.java
@@ -1,5 +1,9 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.domain.view.service;
 
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.entities.EventStream;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.valueobjects.EventStreamChangedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.valueobjects.EventStreamDeletedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingEventStreamException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.exception.DuplicateViewException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.exception.MissingViewException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.repository.ViewRepository;
@@ -14,6 +18,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,6 +35,8 @@ public class ViewServiceImpl implements ViewService {
 	private final ViewRepository viewRepository;
 	private final ApplicationEventPublisher eventPublisher;
 
+	private final HashMap<String, EventStream> eventStreams = new HashMap<>();
+
 	public ViewServiceImpl(DcatViewService dcatViewService, ViewRepository viewRepository,
 			ApplicationEventPublisher eventPublisher) {
 		this.dcatViewService = dcatViewService;
@@ -39,13 +46,19 @@ public class ViewServiceImpl implements ViewService {
 
 	@Override
 	public void addView(ViewSpecification viewSpecification) {
+		if (!eventStreamIsPresent(viewSpecification.getName().getCollectionName())) {
+			throw new MissingEventStreamException(viewSpecification.getName().getCollectionName());
+		}
 		Optional<ViewSpecification> view = viewRepository.getViewByViewName(viewSpecification.getName());
 		if (view.isPresent()) {
 			throw new DuplicateViewException(viewSpecification.getName());
 		}
-
-		viewRepository.saveView(viewSpecification);
 		eventPublisher.publishEvent(new ViewAddedEvent(viewSpecification));
+		viewRepository.saveView(viewSpecification);
+	}
+
+	private boolean eventStreamIsPresent(String collectionName) {
+		return eventStreams.containsKey(collectionName);
 	}
 
 	@Override
@@ -61,7 +74,10 @@ public class ViewServiceImpl implements ViewService {
 
 	@Override
 	public ViewSpecification getViewByViewName(ViewName viewName) {
-		var viewSpecification = viewRepository.getViewByViewName(viewName)
+		if (!eventStreamIsPresent(viewName.getCollectionName())) {
+			throw new MissingEventStreamException(viewName.getCollectionName());
+		}
+		ViewSpecification viewSpecification = viewRepository.getViewByViewName(viewName)
 				.orElseThrow(() -> new MissingViewException(viewName));
 		addDcatToViewSpecification(viewSpecification);
 		return viewSpecification;
@@ -69,7 +85,10 @@ public class ViewServiceImpl implements ViewService {
 
 	@Override
 	public List<ViewSpecification> getViewsByCollectionName(String collectionName) {
-		var viewSpecifications = viewRepository.retrieveAllViewsOfCollection(collectionName);
+		if (!eventStreamIsPresent(collectionName)) {
+			throw new MissingEventStreamException(collectionName);
+		}
+		List<ViewSpecification> viewSpecifications = viewRepository.retrieveAllViewsOfCollection(collectionName);
 		viewSpecifications.forEach(this::addDcatToViewSpecification);
 		return viewSpecifications;
 	}
@@ -80,6 +99,13 @@ public class ViewServiceImpl implements ViewService {
 
 	@Override
 	public void deleteViewByViewName(ViewName viewName) {
+		if (!eventStreamIsPresent(viewName.getCollectionName())) {
+			throw new MissingEventStreamException(viewName.getCollectionName());
+		}
+		Optional<ViewSpecification> view = viewRepository.getViewByViewName(viewName);
+		if (view.isEmpty()) {
+			throw new MissingViewException(viewName);
+		}
 		viewRepository.deleteViewByViewName(viewName);
 		dcatViewService.delete(viewName);
 		eventPublisher.publishEvent(new ViewDeletedEvent(viewName));
@@ -91,6 +117,16 @@ public class ViewServiceImpl implements ViewService {
 				.retrieveAllViews()
 				.forEach(viewSpecification -> eventPublisher
 						.publishEvent(new ViewInitializationEvent(viewSpecification)));
+	}
+
+	@EventListener
+	public void handleEventStreamInitEvent(EventStreamChangedEvent event) {
+		eventStreams.put(event.eventStream().getCollection(), event.eventStream());
+	}
+
+	@EventListener
+	public void handleEventStreamDeletedEvent(EventStreamDeletedEvent event) {
+		eventStreams.remove(event.collectionName());
 	}
 
 }

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/service/ViewServiceImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/view/service/ViewServiceImplTest.java
@@ -1,5 +1,8 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.domain.view.service;
 
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.entities.EventStream;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.valueobjects.EventStreamChangedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingEventStreamException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.exception.DuplicateViewException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.exception.MissingViewException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.repository.ViewRepository;
@@ -8,6 +11,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.Vi
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewInitializationEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -25,56 +29,77 @@ class ViewServiceImplTest {
 	private final DcatViewService dcatViewService = mock(DcatViewService.class);
 	private final ViewRepository viewRepository = mock(ViewRepository.class);
 	private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+	private static final String COLLECTION = "collection";
+	private static final String NOT_EXISTING_COLLECTION = "not_existing_collection";
 	private final ViewServiceImpl viewService = new ViewServiceImpl(dcatViewService, viewRepository, eventPublisher);
+
+	@BeforeEach
+	void setUp() {
+		viewService.handleEventStreamInitEvent(
+				new EventStreamChangedEvent(new EventStream(COLLECTION, null, null, null, false)));
+	}
 
 	@Nested
 	class AddView {
-		private final ViewSpecification view = new ViewSpecification(new ViewName("collection", "view"), List.of(),
+		private final ViewSpecification view = new ViewSpecification(new ViewName(COLLECTION, "view"), List.of(),
+				List.of());
+		private final ViewSpecification viewOfNotExistingCollection = new ViewSpecification(
+				new ViewName(NOT_EXISTING_COLLECTION, "view"), List.of(),
 				List.of());
 
 		@Test
-		void when_ViewDoesNotExist_ViewIsAdded() {
-			when(viewRepository.getViewByViewName(view.getName())).thenReturn(Optional.empty());
+        void when_ViewDoesNotExist_then_ViewIsAdded() {
+            when(viewRepository.getViewByViewName(view.getName())).thenReturn(Optional.empty());
 
-			viewService.addView(view);
+            viewService.addView(view);
 
-			InOrder inOrder = inOrder(viewRepository, eventPublisher);
-			inOrder.verify(viewRepository).getViewByViewName(view.getName());
-			inOrder.verify(viewRepository).saveView(view);
-			inOrder.verify(eventPublisher).publishEvent(any(ViewAddedEvent.class));
-			inOrder.verifyNoMoreInteractions();
-		}
+            InOrder inOrder = inOrder(viewRepository, eventPublisher);
+            inOrder.verify(viewRepository).getViewByViewName(view.getName());
+            inOrder.verify(eventPublisher).publishEvent(any(ViewAddedEvent.class));
+            inOrder.verify(viewRepository).saveView(view);
+            inOrder.verifyNoMoreInteractions();
+        }
 
 		@Test
-		void when_ViewDoesExist_DuplicateViewExceptionIsThrown() {
-			when(viewRepository.getViewByViewName(view.getName())).thenReturn(Optional.of(view));
+        void when_ViewDoesExist_then_DuplicateViewExceptionIsThrown() {
+            when(viewRepository.getViewByViewName(view.getName())).thenReturn(Optional.of(view));
 
-			DuplicateViewException duplicateViewException = assertThrows(DuplicateViewException.class, () -> viewService.addView(view));
+            DuplicateViewException duplicateViewException = assertThrows(DuplicateViewException.class, () -> viewService.addView(view));
 
-			assertEquals("Collection collection already has a view: view", duplicateViewException.getMessage());
+            assertEquals("Collection collection already has a view: view", duplicateViewException.getMessage());
+            InOrder inOrder = inOrder(viewRepository, eventPublisher);
+            inOrder.verify(viewRepository).getViewByViewName(view.getName());
+            inOrder.verifyNoMoreInteractions();
+        }
+
+		@Test
+		void when_EventStreamDoesNotExist_then_MissingEventStreamExceptionIsThrown() {
+			MissingEventStreamException missingEventStreamException = assertThrows(MissingEventStreamException.class,
+					() -> viewService.addView(viewOfNotExistingCollection));
+
+			assertEquals("No event stream found for collection not_existing_collection",
+					missingEventStreamException.getMessage());
 			InOrder inOrder = inOrder(viewRepository, eventPublisher);
-			inOrder.verify(viewRepository).getViewByViewName(view.getName());
 			inOrder.verifyNoMoreInteractions();
 		}
 	}
 
 	@Nested
 	class AddDefaultView {
-		private static final String COLLECTION = "collection";
 		private static final ViewName VIEW_NAME = new ViewName(COLLECTION, "by-page");
 
 		@Test
-		void when_DefaultViewDoesNotExist_then_DefaultViewIsAdded() {
-			when(viewRepository.getViewByViewName(VIEW_NAME)).thenReturn(Optional.empty());
+        void when_DefaultViewDoesNotExist_then_DefaultViewIsAdded() {
+            when(viewRepository.getViewByViewName(VIEW_NAME)).thenReturn(Optional.empty());
 
-			viewService.addDefaultView(COLLECTION);
+            viewService.addDefaultView(COLLECTION);
 
-			InOrder inOrder = inOrder(viewRepository, eventPublisher);
-			inOrder.verify(viewRepository).getViewByViewName(VIEW_NAME);
-			inOrder.verify(viewRepository).saveView(any(ViewSpecification.class));
-			inOrder.verify(eventPublisher).publishEvent(any(ViewAddedEvent.class));
-			inOrder.verifyNoMoreInteractions();
-		}
+            InOrder inOrder = inOrder(viewRepository, eventPublisher);
+            inOrder.verify(viewRepository).getViewByViewName(VIEW_NAME);
+            inOrder.verify(eventPublisher).publishEvent(any(ViewAddedEvent.class));
+            inOrder.verify(viewRepository).saveView(any(ViewSpecification.class));
+            inOrder.verifyNoMoreInteractions();
+        }
 
 		@Test
 		void when_DefaultViewExists_then_ThrowDuplicateViewExcpetion() {
@@ -91,26 +116,65 @@ class ViewServiceImplTest {
 
 	@Nested
 	class DeleteView {
-		private final ViewName viewName = new ViewName("collection", "view");
+		private final ViewName viewName = new ViewName(COLLECTION, "view");
+		private final ViewName viewNameOfNotExistingCollection = new ViewName(NOT_EXISTING_COLLECTION, "view");
+		private final ViewName notExistingViewName = new ViewName(COLLECTION, "not_existing_view");
 
 		@Test
-		void when_ViewDoesNotExist_ViewIsAdded() {
-			viewService.deleteViewByViewName(viewName);
+		void when_DeleteViewAndEventStreamDoesNotExist_then_MissingEventStreamExceptionIsThrown() {
+			MissingEventStreamException missingEventStreamException = assertThrows(MissingEventStreamException.class,
+					() -> viewService.deleteViewByViewName(viewNameOfNotExistingCollection));
 
-			InOrder inOrder = inOrder(viewRepository, eventPublisher, dcatViewService);
-			inOrder.verify(viewRepository).deleteViewByViewName(viewName);
-			inOrder.verify(dcatViewService).delete(viewName);
-			inOrder.verify(eventPublisher).publishEvent(any(ViewDeletedEvent.class));
+			assertEquals("No event stream found for collection not_existing_collection",
+					missingEventStreamException.getMessage());
+			InOrder inOrder = inOrder(viewRepository, eventPublisher);
 			inOrder.verifyNoMoreInteractions();
 		}
+
+		@Test
+		void when_DeleteViewAndViewDoesNotExist_then_MissingViewExceptionIsThrown() {
+			MissingViewException missingViewException = assertThrows(MissingViewException.class,
+					() -> viewService.deleteViewByViewName(notExistingViewName));
+
+			assertEquals("Collection collection does not have a view: not_existing_view",
+					missingViewException.getMessage());
+			InOrder inOrder = inOrder(viewRepository, eventPublisher);
+			inOrder.verify(viewRepository).getViewByViewName(notExistingViewName);
+			inOrder.verifyNoMoreInteractions();
+		}
+
+		@Test
+        void when_DeleteViewAndViewExists_then_ViewIsDeleted() {
+            when(viewRepository.getViewByViewName(viewName)).thenReturn(Optional.of(new ViewSpecification()));
+
+            viewService.deleteViewByViewName(viewName);
+
+            InOrder inOrder = inOrder(viewRepository, eventPublisher, dcatViewService);
+            inOrder.verify(viewRepository).deleteViewByViewName(viewName);
+            inOrder.verify(dcatViewService).delete(viewName);
+            inOrder.verify(eventPublisher).publishEvent(any(ViewDeletedEvent.class));
+            inOrder.verifyNoMoreInteractions();
+        }
 	}
 
 	@Nested
 	class GetView {
-		private final ViewName viewName = new ViewName("collection", "view");
+		private final ViewName viewName = new ViewName(COLLECTION, "view");
 
 		@Test
-		void when_GetViewAndViewIsPresent_ViewIsReturned() {
+		void when_GetViewAndEventStreamDoesNotExist_then_then_MissingEventStreamExceptionIsThrown() {
+			ViewName viewNameOfNotExistingCollection = new ViewName(NOT_EXISTING_COLLECTION, "view");
+			MissingEventStreamException missingEventStreamException = assertThrows(MissingEventStreamException.class,
+					() -> viewService.getViewByViewName(viewNameOfNotExistingCollection));
+
+			assertEquals("No event stream found for collection not_existing_collection",
+					missingEventStreamException.getMessage());
+			InOrder inOrder = inOrder(viewRepository, eventPublisher);
+			inOrder.verifyNoMoreInteractions();
+		}
+
+		@Test
+		void when_GetViewAndViewIsPresent_then_ViewIsReturned() {
 			ViewSpecification expectedViewSpecification = new ViewSpecification(viewName, List.of(), List.of());
 			when(viewRepository.getViewByViewName(viewName)).thenReturn(Optional.of(expectedViewSpecification));
 
@@ -123,44 +187,55 @@ class ViewServiceImplTest {
 		}
 
 		@Test
-		void when_GetViewAndViewIsNotPresent_ViewIsReturned() {
-			when(viewRepository.getViewByViewName(viewName)).thenReturn(Optional.empty());
+        void when_GetViewAndViewIsNotPresent_then_MissingViewExceptionIsThrown() {
+            when(viewRepository.getViewByViewName(viewName)).thenReturn(Optional.empty());
 
-			MissingViewException missingViewException = assertThrows(MissingViewException.class, () -> viewService.getViewByViewName(viewName));
+            MissingViewException missingViewException = assertThrows(MissingViewException.class, () -> viewService.getViewByViewName(viewName));
 
-			assertEquals("Collection collection does not have a view: view", missingViewException.getMessage());
-			InOrder inOrder = inOrder(viewRepository, eventPublisher);
-			inOrder.verify(viewRepository).getViewByViewName(viewName);
-			inOrder.verifyNoMoreInteractions();
-		}
+            assertEquals("Collection collection does not have a view: view", missingViewException.getMessage());
+            InOrder inOrder = inOrder(viewRepository, eventPublisher);
+            inOrder.verify(viewRepository).getViewByViewName(viewName);
+            inOrder.verifyNoMoreInteractions();
+        }
 	}
 
 	@Nested
 	class GetViewsOfCollection {
-		private final ViewName viewName = new ViewName("collection", "view");
+		private final ViewName viewName = new ViewName(COLLECTION, "view");
 		private final ViewSpecification expectedViewSpecification = new ViewSpecification(viewName, List.of(),
 				List.of());
 
 		@Test
-		void when_GetViewAndViewIsPresent_ViewIsReturned() {
-			when(viewRepository.retrieveAllViewsOfCollection(viewName.getCollectionName())).thenReturn(List.of(expectedViewSpecification));
+		void when_GetViewsByCollectionNameAndEventStreamDoesNotExist_then_MissingEventStreamExceptionIsThrown() {
+			MissingEventStreamException missingEventStreamException = assertThrows(MissingEventStreamException.class,
+					() -> viewService.getViewsByCollectionName(NOT_EXISTING_COLLECTION));
 
-			List<ViewSpecification> actualViewSpecifications = viewService.getViewsByCollectionName(viewName.getCollectionName());
-
-			assertEquals(List.of(expectedViewSpecification), actualViewSpecifications);
+			assertEquals("No event stream found for collection not_existing_collection",
+					missingEventStreamException.getMessage());
 			InOrder inOrder = inOrder(viewRepository, eventPublisher);
-			inOrder.verify(viewRepository).retrieveAllViewsOfCollection(viewName.getCollectionName());
 			inOrder.verifyNoMoreInteractions();
 		}
+
+		@Test
+        void when_GetViewsByCollectionName_then_ViewsAreReturned() {
+            when(viewRepository.retrieveAllViewsOfCollection(viewName.getCollectionName())).thenReturn(List.of(expectedViewSpecification));
+
+            List<ViewSpecification> actualViewSpecifications = viewService.getViewsByCollectionName(viewName.getCollectionName());
+
+            assertEquals(List.of(expectedViewSpecification), actualViewSpecifications);
+            InOrder inOrder = inOrder(viewRepository, eventPublisher);
+            inOrder.verify(viewRepository).retrieveAllViewsOfCollection(viewName.getCollectionName());
+            inOrder.verifyNoMoreInteractions();
+        }
 	}
 
 	@Nested
 	class InitViews {
 		@Test
-		void when_ApplicationIsStartedUp_ViewAddedEventsAreSent() {
-			ViewSpecification firstViewSpecification = new ViewSpecification(new ViewName("collection", "view"),
+		void when_ApplicationIsStartedUp_then_ViewAddedEventsAreSent() {
+			ViewSpecification firstViewSpecification = new ViewSpecification(new ViewName(COLLECTION, "view"),
 					List.of(), List.of());
-			ViewSpecification secondViewSpecification = new ViewSpecification(new ViewName("collection", "view2"),
+			ViewSpecification secondViewSpecification = new ViewSpecification(new ViewName(COLLECTION, "view2"),
 					List.of(), List.of());
 			when(viewRepository.retrieveAllViews())
 					.thenReturn(List.of(firstViewSpecification, secondViewSpecification));

--- a/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/OpenApiAdminViewsRestController.java
+++ b/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/OpenApiAdminViewsRestController.java
@@ -1,0 +1,99 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.admin.rest.controllers;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.jena.rdf.model.Model;
+
+import java.util.List;
+
+import static org.apache.jena.riot.WebContent.*;
+
+@Tag(name = "Views")
+@SuppressWarnings("java:S2479") // whitespace needed for examples
+public interface OpenApiAdminViewsRestController {
+
+	@Operation(summary = "Retrieve a list of configured views of a collection")
+	@ApiResponse(responseCode = "200", content = {
+			@Content(mediaType = contentTypeTurtle),
+			@Content(mediaType = contentTypeJSONLD),
+			@Content(mediaType = contentTypeNQuads) })
+	@ApiResponse(responseCode = "404", description = "Missing EventStream")
+	List<ViewSpecification> getViews(
+			@Parameter(description = "The name of the collection", example = "mobility-hindrances") String collectionName);
+
+	@Operation(summary = "Retrieve a specific view of a collection")
+	@ApiResponse(responseCode = "200", content = {
+			@Content(mediaType = contentTypeTurtle),
+			@Content(mediaType = contentTypeJSONLD),
+			@Content(mediaType = contentTypeNQuads) })
+	@ApiResponse(responseCode = "404", description = "Missing EventStream or Missing View")
+	ViewSpecification getViewOfCollection(
+			@Parameter(description = "The name of the collection", example = "mobility-hindrances") String collectionName,
+			@Parameter(description = "The name of requested view", example = "time-based-retention") String viewName);
+
+	@Operation(summary = "Delete a specific view for a collection")
+	@ApiResponse(responseCode = "200", content = {
+			@Content(mediaType = contentTypeTurtle),
+			@Content(mediaType = contentTypeJSONLD),
+			@Content(mediaType = contentTypeNQuads) })
+	@ApiResponse(responseCode = "404", description = "Missing EventStream or Missing View")
+	void deleteView(
+			@Parameter(description = "The name of the collection", example = "mobility-hindrances") String collectionName,
+			@Parameter(description = "The name of deleted view", example = "time-based-retention") String viewName);
+
+	@ApiResponse(responseCode = "200")
+	@ApiResponse(responseCode = "400", description = "Duplicate View or Wrongly Configured View")
+	@ApiResponse(responseCode = "404", description = "Missing EventStream")
+	@Operation(summary = "Add view to a collection")
+	void createView(
+			@Parameter(description = "The name of the collection", example = "mobility-hindrances") String collectionName,
+			@RequestBody(description = "A valid RDF model defining a view for a collection", content = {
+					@Content(mediaType = contentTypeTurtle, schema = @Schema(implementation = String.class), examples = {
+							@ExampleObject(name = "Time-Based Retention", description = "A time-based retention policy which is configured to only keep members whose ldes:timestamppath is less than 2 minutes ago.", value = """
+									@prefix ldes: <https://w3id.org/ldes#> .
+									@prefix tree: <https://w3id.org/tree#>.
+									@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+									@prefix server: <http://localhost:8080/mobility-hindrances/> .
+
+									server:time-based-retention tree:viewDescription [
+									    ldes:retentionPolicy [
+									        a ldes:DurationAgoPolicy  ;
+									        tree:value "PT2M"^^xsd:duration ;
+									    ] ;
+									] .
+									"""),
+							@ExampleObject(name = "Version-Based Retention", description = "A version-based retention policy which is configured to only keep members the two most recent versions of a resource.", value = """
+									@prefix ldes: <https://w3id.org/ldes#> .
+									@prefix tree: <https://w3id.org/tree#>.
+									@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+									@prefix server: <http://localhost:8080/mobility-hindrances/> .
+
+									server:version-based-retention tree:viewDescription [
+									    ldes:retentionPolicy [
+									        a ldes:LatestVersionSubset;
+									        ldes:amount 2 ;
+									    ] ;
+									] .
+									"""),
+							@ExampleObject(name = "Point-In-Time Retention", description = "A point-in-time retention policy which is configured to only keep members whose ldes:timestamppath is after April 12, 2023.", value = """
+									@prefix ldes: <https://w3id.org/ldes#> .
+									@prefix tree: <https://w3id.org/tree#>.
+									@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+									@prefix server: <http://localhost:8080/mobility-hindrances/> .
+
+									server:point-in-time-retention tree:viewDescription [
+									    ldes:retentionPolicy [
+									        a ldes:PointInTimePolicy ;
+									        ldes:pointInTime "2023-04-12T00:00:00"^^xsd:dateTime
+									    ] ;
+									] .
+									""") })
+			}) Model view);
+}

--- a/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/converters/ListViewHttpConverter.java
+++ b/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/converters/ListViewHttpConverter.java
@@ -18,6 +18,9 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import static be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.RdfModelConverter.getLang;
+import static be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.RdfFormatException.RdfFormatContext.FETCH;
+
 public class ListViewHttpConverter implements GenericHttpMessageConverter<List<ViewSpecification>> {
 	private static final MediaType DEFAULT_MEDIA_TYPE = MediaType.valueOf("text/turtle");
 	private final ViewSpecificationConverter viewSpecificationConverter;
@@ -74,9 +77,10 @@ public class ListViewHttpConverter implements GenericHttpMessageConverter<List<V
 	@Override
 	public void write(List<ViewSpecification> views, MediaType contentType,
 			HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+		Lang rdfFormat = getLang(contentType, FETCH);
 		Model model = ModelFactory.createDefaultModel();
 		views.stream().map(viewSpecificationConverter::modelFromView).forEach(model::add);
 
-		RDFDataMgr.write(outputMessage.getBody(), model, Lang.TURTLE);
+		RDFDataMgr.write(outputMessage.getBody(), model, rdfFormat);
 	}
 }

--- a/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/converters/ViewHttpConverter.java
+++ b/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/converters/ViewHttpConverter.java
@@ -3,6 +3,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.admin.rest.converters;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.service.ViewSpecificationConverter;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewSpecification;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
@@ -16,7 +17,8 @@ import java.io.OutputStream;
 import java.io.StringWriter;
 import java.util.List;
 
-import static org.apache.jena.riot.RDFFormat.TURTLE;
+import static be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.RdfModelConverter.getLang;
+import static be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.RdfFormatException.RdfFormatContext.FETCH;
 
 public class ViewHttpConverter implements HttpMessageConverter<ViewSpecification> {
 
@@ -50,10 +52,11 @@ public class ViewHttpConverter implements HttpMessageConverter<ViewSpecification
 	@Override
 	public void write(ViewSpecification view, MediaType contentType, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException {
+		Lang rdfFormat = getLang(contentType, FETCH);
 		StringWriter outputStream = new StringWriter();
 		Model model = viewSpecificationConverter.modelFromView(view);
 
-		RDFDataMgr.write(outputStream, model, TURTLE);
+		RDFDataMgr.write(outputStream, model, rdfFormat);
 
 		OutputStream body = outputMessage.getBody();
 		body.write(outputStream.toString().getBytes());

--- a/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/exceptionhandling/AdminRestResponseEntityExceptionHandler.java
+++ b/ldes-server-port-admin-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/exceptionhandling/AdminRestResponseEntityExceptionHandler.java
@@ -7,6 +7,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.LdesShac
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingEventStreamException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingShaclShapeException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.snapshot.exception.SnapshotCreationException;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.exception.DuplicateViewException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.exception.MissingViewDcatException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.exception.MissingViewException;
 import org.apache.jena.riot.RiotException;
@@ -30,7 +31,7 @@ public class AdminRestResponseEntityExceptionHandler extends ResponseEntityExcep
 	}
 
 	@ExceptionHandler(value = { LdesShaclValidationException.class, RiotException.class,
-			DcatAlreadyConfiguredException.class, IllegalArgumentException.class })
+			DcatAlreadyConfiguredException.class, IllegalArgumentException.class, DuplicateViewException.class })
 	protected ResponseEntity<Object> handleBadRequest(
 			RuntimeException ex, WebRequest request) {
 		return handleException(ex, HttpStatus.BAD_REQUEST, request);

--- a/ldes-server-port-admin-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/AdminViewsRestControllerTest.java
+++ b/ldes-server-port-admin-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/AdminViewsRestControllerTest.java
@@ -44,9 +44,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest
@@ -79,7 +77,8 @@ class AdminViewsRestControllerTest {
 		when(viewService.getViewsByCollectionName(collectionName)).thenReturn(List.of(view1, view2));
 
 		ResultActions resultActions = mockMvc
-				.perform(get("/admin/api/v1/eventstreams/" + collectionName + "/views"))
+				.perform(get("/admin/api/v1/eventstreams/" + collectionName + "/views")
+						.accept(contentTypeTurtle))
 				.andExpect(status().isOk());
 		MvcResult result = resultActions.andReturn();
 		Model actualModel = RdfModelConverter.fromString(result.getResponse().getContentAsString(), Lang.TURTLE);
@@ -122,7 +121,7 @@ class AdminViewsRestControllerTest {
 		Model expectedViewModel = readModelFromFile("view-1.ttl");
 		ViewSpecification view = converter.viewFromModel(expectedViewModel, collectionName);
 
-		mockMvc.perform(put("/admin/api/v1/eventstreams/" + collectionName + "/views")
+		mockMvc.perform(post("/admin/api/v1/eventstreams/" + collectionName + "/views")
 				.content(readDataFromFile("view-1.ttl"))
 				.contentType(Lang.TURTLE.getHeaderString()))
 				.andExpect(status().isOk());
@@ -132,7 +131,7 @@ class AdminViewsRestControllerTest {
 	@Test
 	void when_StreamEndpointCalledAndModelInRequestBody_Then_ModelIsValidated() throws Exception {
 		String collectionName = "name1";
-		mockMvc.perform(put("/admin/api/v1/eventstreams/" + collectionName + "/views")
+		mockMvc.perform(post("/admin/api/v1/eventstreams/" + collectionName + "/views")
 				.content(readDataFromFile("view-1.ttl"))
 				.contentType(Lang.TURTLE.getHeaderString()));
 		verify(validator, times(1)).validate(any(), any());

--- a/ldes-server-port-admin-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/integration/AdminEventStreamsRestControllerSteps.java
+++ b/ldes-server-port-admin-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/rest/controllers/integration/AdminEventStreamsRestControllerSteps.java
@@ -5,6 +5,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.admin.rest.controllers.IsI
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.PrefixAdderImpl;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.entities.EventStream;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.repository.EventStreamRepository;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.valueobjects.EventStreamChangedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.shacl.entities.ShaclShape;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.shacl.repository.ShaclShapeRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.repository.ViewRepository;
@@ -17,6 +18,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.cucumber.plugin.event.EventPublisher;
 import io.cucumber.spring.CucumberContextConfiguration;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
@@ -27,6 +29,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -79,6 +82,8 @@ public class AdminEventStreamsRestControllerSteps {
 	private ShaclShapeRepository shaclShapeRepository;
 	@Autowired
 	private MockMvc mockMvc;
+	@Autowired
+	private ApplicationEventPublisher eventPublisher;
 
 	@Given("a db containing multiple eventstreams")
 	public void aDbContainingMultipleEventstreams() throws URISyntaxException {
@@ -87,6 +92,8 @@ public class AdminEventStreamsRestControllerSteps {
 				false);
 		final EventStream eventStream2 = new EventStream(collection2, TIMESTAMP_PATH, VERSION_OF_PATH, MEMBER_TYPE,
 				true);
+		eventPublisher.publishEvent(new EventStreamChangedEvent(eventStream));
+		eventPublisher.publishEvent(new EventStreamChangedEvent(eventStream2));
 		Model shape = readModelFromFile("example-shape.ttl");
 		FragmentationConfig fragmentationConfig = new FragmentationConfig();
 		fragmentationConfig.setName("fragmentationStrategy");


### PR DESCRIPTION
In this PR:
* examples and documentation for adding, getting and deleting views via the Admin interface
* Saving an eventstream triggers also the saving of viewspecifications
* Saving an eventstream sends out an `EventStreamChangedEvent`
* Checks in the `ViewServiceImpl` to verify that eventstreams exists when adding, retrieving or deleting views
* Check in the `ViewServiceImpl` to verify that view exists before deleting
* Put -> Post for creating View