### PR TITLE
bugfix: more performant way to delete all members of a collection

### DIFF
--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/tree/member/repository/MemberRepository.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/tree/member/repository/MemberRepository.java
@@ -16,6 +16,8 @@ public interface MemberRepository {
 
 	void deleteMember(String memberId);
 
+	void deleteMembersByCollection(String collection);
+
 	void addMemberReference(String memberId, String fragmentId);
 
 	Stream<Member> getMembersByReference(String treeNodeId);

--- a/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/tree/member/services/MemberIngestServiceImpl.java
+++ b/ldes-server-domain/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/tree/member/services/MemberIngestServiceImpl.java
@@ -41,9 +41,7 @@ public class MemberIngestServiceImpl implements MemberIngestService {
 
 	@EventListener
 	public void handleEventStreamDeletedEvent(EventStreamDeletedEvent event) {
-		memberRepository.getMemberStreamOfCollection(event.collectionName())
-				.map(Member::getLdesMemberId)
-				.forEach(memberRepository::deleteMember);
+		memberRepository.deleteMembersByCollection(event.collectionName());
 	}
 
 	private Member storeLdesMember(Member member) {

--- a/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/tree/member/services/MemberIngestServiceImplTest.java
+++ b/ldes-server-domain/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/domain/tree/member/services/MemberIngestServiceImplTest.java
@@ -87,8 +87,7 @@ class MemberIngestServiceImplTest {
 		when(memberRepository.getMemberStreamOfCollection(collection)).thenReturn(Stream.of(member));
 		((MemberIngestServiceImpl) memberIngestService)
 				.handleEventStreamDeletedEvent(new EventStreamDeletedEvent(collection));
-		InOrder inOrder = inOrder(memberRepository);
-		inOrder.verify(memberRepository).getMemberStreamOfCollection(collection);
-		inOrder.verify(memberRepository).deleteMember(memberId);
+		verify(memberRepository).deleteMembersByCollection(collection);
+		verifyNoMoreInteractions(memberRepository);
 	}
 }

--- a/ldes-server-infra-mongo/mongo-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/member/MemberMongoRepository.java
+++ b/ldes-server-infra-mongo/mongo-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/member/MemberMongoRepository.java
@@ -54,6 +54,11 @@ public class MemberMongoRepository implements MemberRepository {
 	}
 
 	@Override
+	public void deleteMembersByCollection(String collection) {
+		repository.deleteAllByCollectionName(collection);
+	}
+
+	@Override
 	public synchronized void addMemberReference(String memberId, String fragmentId) {
 		Query query = new Query();
 		query.addCriteria(Criteria.where("_id").is(memberId));

--- a/ldes-server-infra-mongo/mongo-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/member/repository/LdesMemberEntityRepository.java
+++ b/ldes-server-infra-mongo/mongo-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/member/repository/LdesMemberEntityRepository.java
@@ -4,5 +4,5 @@ import be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.member.entity.
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface LdesMemberEntityRepository extends MongoRepository<LdesMemberEntity, String> {
-
+	void deleteAllByCollectionName(String collectionName);
 }

--- a/ldes-server-infra-mongo/mongo-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/member/MemberRepositorySteps.java
+++ b/ldes-server-infra-mongo/mongo-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/member/MemberRepositorySteps.java
@@ -15,8 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MemberRepositorySteps extends SpringIntegrationTest {
 
@@ -60,4 +59,20 @@ public class MemberRepositorySteps extends SpringIntegrationTest {
 		assertThat(member.getTimestamp()).isEqualToIgnoringNanos(retrievedMemberPresent.getTimestamp());
 		assertEquals(member.getTreeNodeReferences(), retrievedMemberPresent.getTreeNodeReferences());
 	}
+
+	@Then("The member with id {string} will exist")
+	public void theMemberWithIdWillExist(String id) {
+		assertTrue(memberRepository.memberExists(id));
+	}
+
+	@And("The member with id {string} will not exist")
+	public void theMemberWithIdWillNotExist(String id) {
+		assertFalse(memberRepository.memberExists(id));
+	}
+
+	@When("I delete all the members of collection {string}")
+	public void iDeleteAllTheMembersOfCollection(String collectionName) {
+		memberRepository.deleteMembersByCollection(collectionName);
+	}
+
 }

--- a/ldes-server-infra-mongo/mongo-repository/src/test/resources/features/member/member.feature
+++ b/ldes-server-infra-mongo/mongo-repository/src/test/resources/features/member/member.feature
@@ -29,3 +29,19 @@ Feature: MemberRepository
     And The retrieved member has the same properties as the 3 member in the table and has sequenceNr 1
     Then The member with id "http://test-data/gipod/1/2" can be retrieved from the database
     And The retrieved member has the same properties as the 5 member in the table and has sequenceNr 2
+
+
+  Scenario: The repository can delete all members of a certain collection
+    Given The following members
+      | id                                      | collectionName      | sequenceNr | versionOf                             |
+      | http://test-data/mobility-hindrance/1/1 | mobility-hindrances | [blank]    | http://test-data/mobility-hindrance/1 |
+      | http://test-data/mobility-hindrance/1/2 | mobility-hindrances | [blank]    | http://test-data/mobility-hindrance/1 |
+      | http://test-data/gipod/1/1              | gipod               | [blank]    | http://test-data/gipod/1              |
+      | http://test-data/mobility-hindrance/1/3 | mobility-hindrances | [blank]    | http://test-data/mobility-hindrance/1 |
+      | http://test-data/gipod/1/2              | gipod               | [blank]    | http://test-data/gipod/1              |
+    When I save the members using the MemberRepository
+    Then The member with id "http://test-data/gipod/1/1" will exist
+    When I delete all the members of collection "gipod"
+    Then The member with id "http://test-data/mobility-hindrance/1/1" will exist
+    And The member with id "http://test-data/gipod/1/1" will not exist
+    And The member with id "http://test-data/gipod/1/2" will not exist


### PR DESCRIPTION
Now in the original domain module, all members of a certain collection can be deleted at once