### PR TITLE
Feat/remove index

### DIFF
--- a/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset2/config/AppConfigChangeset2.java
+++ b/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset2/config/AppConfigChangeset2.java
@@ -15,6 +15,9 @@ public class AppConfigChangeset2 {
 		this.collections = collections != null ? collections : new ArrayList<>();
 	}
 
+	public AppConfigChangeset2() {
+	}
+
 	public List<LdesConfig> getCollections() {
 		return collections;
 	}

--- a/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset3/config/AppConfigChangeset3.java
+++ b/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset3/config/AppConfigChangeset3.java
@@ -15,6 +15,9 @@ public class AppConfigChangeset3 {
 		this.collections = collections != null ? collections : new ArrayList<>();
 	}
 
+	public AppConfigChangeset3() {
+	}
+
 	public List<LdesConfig> getCollections() {
 		return collections;
 	}

--- a/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset7/config/AppConfigChangeset7.java
+++ b/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset7/config/AppConfigChangeset7.java
@@ -15,6 +15,9 @@ public class AppConfigChangeset7 {
 		this.collections = collections != null ? collections : new ArrayList<>();
 	}
 
+	public AppConfigChangeset7() {
+	}
+
 	public List<LdesConfig> getCollections() {
 		return collections;
 	}

--- a/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset8/FragmentUpdaterChange.java
+++ b/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset8/FragmentUpdaterChange.java
@@ -1,0 +1,23 @@
+//package be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.mongock.changeset8;
+//
+//import io.mongock.api.annotations.ChangeUnit;
+//import io.mongock.api.annotations.Execution;
+//import org.springframework.data.mongodb.core.MongoTemplate;
+//
+//@ChangeUnit(id = "fragment-updater-changeset-8", order = "8", author = "VSDS")
+//public class FragmentUpdaterChange {
+//	private final MongoTemplate mongoTemplate;
+//
+//	public FragmentUpdaterChange(MongoTemplate mongoTemplate) {
+//		this.mongoTemplate = mongoTemplate;
+//	}
+//
+//	/**
+//	 * This is the method with the migration code
+//	 **/
+//	@Execution
+//	public void changeSet() {
+//		mongoTemplate.indexOps("ldesfragment").dropIndex("softDeleted");
+//	}
+//
+//}

--- a/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset8/FragmentUpdaterChange.java
+++ b/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset8/FragmentUpdaterChange.java
@@ -1,23 +1,26 @@
-//package be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.mongock.changeset8;
-//
-//import io.mongock.api.annotations.ChangeUnit;
-//import io.mongock.api.annotations.Execution;
-//import org.springframework.data.mongodb.core.MongoTemplate;
-//
-//@ChangeUnit(id = "fragment-updater-changeset-8", order = "8", author = "VSDS")
-//public class FragmentUpdaterChange {
-//	private final MongoTemplate mongoTemplate;
-//
-//	public FragmentUpdaterChange(MongoTemplate mongoTemplate) {
-//		this.mongoTemplate = mongoTemplate;
-//	}
-//
-//	/**
-//	 * This is the method with the migration code
-//	 **/
-//	@Execution
-//	public void changeSet() {
-//		mongoTemplate.indexOps("ldesfragment").dropIndex("softDeleted");
-//	}
-//
-//}
+package be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.mongock.changeset8;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@ChangeUnit(id = "fragment-updater-changeset-8", order = "8", author = "VSDS")
+public class FragmentUpdaterChange {
+	private final MongoTemplate mongoTemplate;
+
+	public FragmentUpdaterChange(MongoTemplate mongoTemplate) {
+		this.mongoTemplate = mongoTemplate;
+	}
+
+	@Execution
+	public void changeSet() {
+		mongoTemplate.indexOps("ldesfragment").dropIndex("softDeleted");
+	}
+
+	@RollbackExecution
+	public void rollback() {
+		// No rollback, we don't want to add the index if we fail in deleting it.
+	}
+
+}

--- a/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset8/README.md
+++ b/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset8/README.md
@@ -1,0 +1,15 @@
+# Mongock Changeset 8
+
+In changeset 6 we deleted
+
+Following configuration is needed to apply this changeset.
+
+```
+mongock:
+  migration-scan-package:
+    - be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.mongock.changeset8
+```
+
+Consequences of Changeset:
+* LdesFragments:
+  * Removed index on `softDeleted`

--- a/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset8/README.md
+++ b/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/changeset8/README.md
@@ -1,6 +1,6 @@
 # Mongock Changeset 8
 
-In changeset 6 we deleted
+In changeset 6 we deleted the indexed field softDeleted but the index was never cleaned up.
 
 Following configuration is needed to apply this changeset.
 


### PR DESCRIPTION
In changeset 6 we remove an indexed field but never the index on this field. This changeset removes this lingering index..
This also has a minor fix caused by regression after bumping spring boot 3.1.0 to 3.1.1 where the configuration could no long be loaded