### PR TITLE
Feat: Provide complete integration test for the retention module

### DIFF
--- a/ldes-server-infra-mongo/mongo-retention-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/MemberPropertiesRepositorySteps.java
+++ b/ldes-server-infra-mongo/mongo-retention-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/MemberPropertiesRepositorySteps.java
@@ -21,8 +21,6 @@ public class MemberPropertiesRepositorySteps extends MongoRetentionIntegrationTe
 
 	@DataTableType
 	public MemberProperties memberPropertiesEntryTransformer(Map<String, String> row) {
-		String string = LocalDateTime.now().toString();
-		System.out.println(string);
 		MemberProperties properties = new MemberProperties(
 				row.get("id"),
 				row.get("collectionName"),

--- a/ldes-server-retention/pom.xml
+++ b/ldes-server-retention/pom.xml
@@ -33,6 +33,30 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/repositories/MemberPropertiesRepository.java
+++ b/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/repositories/MemberPropertiesRepository.java
@@ -8,8 +8,6 @@ import java.util.stream.Stream;
 
 public interface MemberPropertiesRepository {
 
-	// TODO Update implementation see
-	// (https://github.com/Informatievlaanderen/VSDS-LDESServer4J/issues/838)
 	void saveMemberPropertiesWithoutViews(MemberProperties memberProperties);
 
 	void save(MemberProperties memberProperties);

--- a/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/repositories/MemberPropertiesRepository.java
+++ b/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/repositories/MemberPropertiesRepository.java
@@ -8,6 +8,8 @@ import java.util.stream.Stream;
 
 public interface MemberPropertiesRepository {
 
+	// TODO Update implementation see
+	// (https://github.com/Informatievlaanderen/VSDS-LDESServer4J/issues/838)
 	void saveMemberPropertiesWithoutViews(MemberProperties memberProperties);
 
 	void save(MemberProperties memberProperties);

--- a/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/RetentionIT.java
+++ b/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/RetentionIT.java
@@ -1,0 +1,11 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.retention.integrationtest;
+
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features")
+public class RetentionIT extends RetentionIntegrationTest {
+}

--- a/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/RetentionIntegrationTest.java
+++ b/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/RetentionIntegrationTest.java
@@ -1,0 +1,27 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.retention.integrationtest;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.retention.repositories.MemberPropertiesRepository;
+import be.vlaanderen.informatievlaanderen.ldes.server.retention.services.retentionpolicy.execution.SchedulingConfig;
+import be.vlaanderen.informatievlaanderen.ldes.server.retention.integrationtest.stub.InMemoryMemberPropertiesRepository;
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+@CucumberContextConfiguration
+@EnableAutoConfiguration
+@RecordApplicationEvents
+@ContextConfiguration(classes = { InMemoryMemberPropertiesRepository.class, SchedulingConfig.class })
+@ComponentScan(value = { "be.vlaanderen.informatievlaanderen.ldes.server.retention" })
+@SuppressWarnings("java:S2187")
+public class RetentionIntegrationTest {
+
+	@Autowired
+	ApplicationEventPublisher applicationEventPublisher;
+
+	@Autowired
+	MemberPropertiesRepository memberPropertiesRepository;
+}

--- a/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/RetentionServiceSteps.java
+++ b/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/RetentionServiceSteps.java
@@ -1,0 +1,140 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.retention.integrationtest;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.fragmentation.MemberAllocatedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.ingest.MemberIngestedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.entities.EventStream;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.eventstream.valueobjects.EventStreamCreatedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.view.valueobject.ViewAddedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.entities.ViewSpecification;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.viewcreation.valueobjects.ViewName;
+import io.cucumber.java.DataTableType;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFParserBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RetentionServiceSteps extends RetentionIntegrationTest {
+
+	public static final String MEMBER_TEMPLATE_FILENAME = "features/data/memberTemplate.ttl";
+
+	@DataTableType
+	public EventStream EventStreamEntryTransformer(Map<String, String> row) {
+		return new EventStream(
+				row.get("collection"),
+				row.get("timestampPath"),
+				row.get("versionOfPath"),
+				row.get("memberType"));
+	}
+
+	@DataTableType
+	public DeletedMember DeletedMemberEntryTransformer(Map<String, String> row) {
+		return new DeletedMember(
+				row.get("id"),
+				Boolean.parseBoolean(row.get("deleted")));
+	}
+
+	@DataTableType
+	public ViewSpecification ViewSpecificationEntryTransformer(Map<String, String> row) throws URISyntaxException {
+		return new ViewSpecification(
+				ViewName.fromString(row.get("viewName")),
+				List.of(readRetentionPolicyFromFile(row.get("rdfDescriptionFileName"))), List.of());
+	}
+
+	@DataTableType
+	public MemberIngestedEvent MemberIngestedEventEntryTransformer(Map<String, String> row)
+			throws URISyntaxException, IOException {
+		return new MemberIngestedEvent(
+				createModel(row.get("versionOf"), row.get("timestamp")),
+				row.get("id"),
+				row.get("collectionName"));
+	}
+
+	@Given("an EventStream with the following properties")
+	public void anEventStreamWithTheFollowingProperties(EventStream eventStream) {
+		applicationEventPublisher.publishEvent(new EventStreamCreatedEvent(eventStream));
+	}
+
+	@And("the following Members are ingested")
+	public void theFollowingMembersAreIngested(List<MemberIngestedEvent> ingestedMembers) {
+		ingestedMembers.forEach(applicationEventPublisher::publishEvent);
+	}
+
+	@When("a view with the following properties is created")
+	public void aViewWithTheFollowingPropertiesIsCreated(ViewSpecification viewSpecification) {
+		ViewAddedEvent viewAddedEvent = new ViewAddedEvent(viewSpecification);
+		applicationEventPublisher.publishEvent(viewAddedEvent);
+	}
+
+	@When("wait for {int} seconds until the scheduler has executed at least once")
+	public void wait_for_seconds_until_the_scheduler_has_executed_at_least_once(Integer secondsToWait) {
+		await()
+				.timeout(secondsToWait + 1, SECONDS)
+				.pollDelay(secondsToWait, SECONDS)
+				.untilAsserted(() -> assertTrue(true));
+	}
+
+	@Then("the following members are deleted")
+	public void the_following_members_are_deleted(List<DeletedMember> deletedMembers) {
+		// Note: it's difficult to capture the MemberUnallocatedEvents and
+		// MemberDeletedEvents, since these are executed in a different thread due to
+		// the Scheduling. The ApplicationEventsApplicationListener from
+		// spring-boot-test is not registered to this thread. Hence, these events do not
+		// pop up in for example ApplicationEvents from spring-boot-test. Therefore, we
+		// use the repository to verify on existence of the members.
+		deletedMembers.forEach(deletedMember -> {
+			if (deletedMember.deleted) {
+				assertTrue(memberPropertiesRepository.retrieve(deletedMember.id).isEmpty());
+			} else {
+				assertTrue(memberPropertiesRepository.retrieve(deletedMember.id).isPresent());
+			}
+		});
+	}
+
+	private Model createModel(String versionOf, String timestamp) throws URISyntaxException, IOException {
+		String modelTemplate = readMemberTemplateFromFile();
+		String updatedModel = modelTemplate.replace("#VERSIONOF", versionOf).replace("#TIMESTAMP", timestamp);
+		return RDFParserBuilder.create()
+				.fromString(updatedModel).lang(Lang.TURTLE)
+				.toModel();
+	}
+
+	private String readMemberTemplateFromFile() throws URISyntaxException, IOException {
+		ClassLoader classLoader = getClass().getClassLoader();
+		URI uri = Objects.requireNonNull(classLoader.getResource(MEMBER_TEMPLATE_FILENAME)).toURI();
+		return Files.lines(Paths.get(uri)).collect(Collectors.joining());
+	}
+
+	private Model readRetentionPolicyFromFile(String fileName) throws URISyntaxException {
+		ClassLoader classLoader = getClass().getClassLoader();
+		String uri = Objects.requireNonNull(classLoader.getResource(fileName)).toURI().toString();
+		return RDFDataMgr.loadModel(uri);
+	}
+
+	@And("the following members are allocated to the view {string}")
+	public void theFollowingMembersAreAllocatedToTheView(String viewName, List<String> members) {
+		members.forEach(member -> {
+			applicationEventPublisher.publishEvent(new MemberAllocatedEvent(member, ViewName.fromString(viewName)));
+		});
+	}
+
+	private record DeletedMember(String id, boolean deleted) {
+	}
+}

--- a/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/RetentionServiceSteps.java
+++ b/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/RetentionServiceSteps.java
@@ -64,7 +64,7 @@ public class RetentionServiceSteps extends RetentionIntegrationTest {
 		return new MemberIngestedEvent(
 				createModel(row.get("versionOf"), row.get("timestamp")),
 				row.get("id"),
-				row.get("collectionName"));
+				row.get("collectionName"), Integer.parseInt(row.get("sequenceNumber")));
 	}
 
 	@Given("an EventStream with the following properties")

--- a/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/stub/InMemoryMemberPropertiesRepository.java
+++ b/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/stub/InMemoryMemberPropertiesRepository.java
@@ -1,0 +1,81 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.retention.integrationtest.stub;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.retention.entities.MemberProperties;
+import be.vlaanderen.informatievlaanderen.ldes.server.retention.repositories.MemberPropertiesRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+@Component
+public class InMemoryMemberPropertiesRepository implements MemberPropertiesRepository {
+
+	private final ConcurrentHashMap<String, MemberProperties> memberPropertiesMap;
+
+	public InMemoryMemberPropertiesRepository() {
+		this.memberPropertiesMap = new ConcurrentHashMap<>();
+	}
+
+	@Override
+	public void saveMemberPropertiesWithoutViews(MemberProperties memberProperties) {
+		memberPropertiesMap.put(memberProperties.getId(), memberProperties);
+	}
+
+	@Override
+	public void save(MemberProperties memberProperties) {
+		memberPropertiesMap.put(memberProperties.getId(), memberProperties);
+	}
+
+	@Override
+	public Optional<MemberProperties> retrieve(String id) {
+		if (memberPropertiesMap.containsKey(id)) {
+			return Optional.of(memberPropertiesMap.get(id));
+		}
+		return Optional.empty();
+	}
+
+	@Override
+	public void addViewReference(String id, String viewName) {
+		memberPropertiesMap.get(id).addViewReference(viewName);
+	}
+
+	@Override
+	public List<MemberProperties> getMemberPropertiesOfVersionAndView(String versionOf, String viewName) {
+		return memberPropertiesMap
+				.values()
+				.stream()
+				.filter(memberProperties -> memberProperties.getVersionOf().equals(versionOf))
+				.filter(memberProperties -> memberProperties.getViewReferences().contains(viewName))
+				.toList();
+	}
+
+	@Override
+	public Stream<MemberProperties> getMemberPropertiesWithViewReference(String viewName) {
+		return memberPropertiesMap
+				.values()
+				.stream()
+				.filter(memberProperties -> memberProperties.getViewReferences().contains(viewName));
+	}
+
+	@Override
+	public void removeViewReference(String id, String viewName) {
+		memberPropertiesMap.get(id).deleteViewReference(viewName);
+	}
+
+	@Override
+	public void removeMemberPropertiesOfCollection(String collectionName) {
+		List<MemberProperties> properties = memberPropertiesMap
+				.values()
+				.stream()
+				.filter(memberProperties -> memberProperties.getCollectionName().equals(collectionName))
+				.toList();
+		properties.forEach(memberProperties -> memberPropertiesMap.remove(memberProperties.getId()));
+	}
+
+	@Override
+	public void deleteById(String id) {
+		memberPropertiesMap.remove(id);
+	}
+}

--- a/ldes-server-retention/src/test/resources/features/data/memberTemplate.ttl
+++ b/ldes-server-retention/src/test/resources/features/data/memberTemplate.ttl
@@ -1,0 +1,9 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:           <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://test-data/mobility-hindrance/1/1>
+  dc:isVersionOf <#VERSIONOF> ;
+  rdf:type <https://data.vlaanderen.be/ns/mobiliteit#Mobiliteitshinder> ;
+  prov:generatedAtTime "#TIMESTAMP"^^xsd:dateTime .

--- a/ldes-server-retention/src/test/resources/features/retention.feature
+++ b/ldes-server-retention/src/test/resources/features/retention.feature
@@ -1,0 +1,112 @@
+Feature: Execute RetentionService
+
+  Background:
+    Given an EventStream with the following properties
+      | collection          | memberType                                                 | timestampPath                             | versionOfPath                        |
+      | mobility-hindrances | https://data.vlaanderen.be/ns/mobiliteit#Mobiliteitshinder | http://www.w3.org/ns/prov#generatedAtTime | http://purl.org/dc/terms/isVersionOf |
+    And the following Members are ingested
+      | id                                       | collectionName      | versionOf                              | timestamp               |
+      | http://test-data/mobility-hindrances/1/1 | mobility-hindrances | http://test-data/mobility-hindrances/1 | 2013-07-01T00:00:00.000 |
+      | http://test-data/mobility-hindrances/1/2 | mobility-hindrances | http://test-data/mobility-hindrances/1 | 2023-07-02T00:00:00.000 |
+      | http://test-data/mobility-hindrances/2/1 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2013-07-01T00:00:00.000 |
+      | http://test-data/mobility-hindrances/2/2 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2013-07-02T00:00:00.000 |
+      | http://test-data/mobility-hindrances/2/3 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2023-07-03T00:00:00.000 |
+      | http://test-data/mobility-hindrances/2/4 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2023-07-04T00:00:00.000 |
+      | http://test-data/mobility-hindrances/3/1 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-01T00:00:00.000 |
+      | http://test-data/mobility-hindrances/3/2 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-02T00:00:00.000 |
+      | http://test-data/mobility-hindrances/3/3 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-03T00:00:00.000 |
+      | http://test-data/mobility-hindrances/3/4 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-04T00:00:00.000 |
+      | http://test-data/mobility-hindrances/3/5 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2023-07-05T00:00:00.000 |
+
+  Scenario: TIME-BASED RETENTION
+    When a view with the following properties is created
+      | viewName                       | rdfDescriptionFileName                        |
+      | mobility-hindrances/time-based | retentionpolicy/timebased/valid_timebased.ttl |
+    And the following members are allocated to the view "mobility-hindrances/time-based"
+      | http://test-data/mobility-hindrances/1/1 |
+      | http://test-data/mobility-hindrances/1/2 |
+      | http://test-data/mobility-hindrances/2/1 |
+      | http://test-data/mobility-hindrances/2/2 |
+      | http://test-data/mobility-hindrances/2/3 |
+      | http://test-data/mobility-hindrances/2/4 |
+      | http://test-data/mobility-hindrances/3/1 |
+      | http://test-data/mobility-hindrances/3/2 |
+      | http://test-data/mobility-hindrances/3/3 |
+      | http://test-data/mobility-hindrances/3/4 |
+      | http://test-data/mobility-hindrances/3/5 |
+    And wait for 11 seconds until the scheduler has executed at least once
+    Then the following members are deleted
+      | id                                       | deleted |
+      | http://test-data/mobility-hindrances/1/1 | true    |
+      | http://test-data/mobility-hindrances/1/2 | false   |
+      | http://test-data/mobility-hindrances/2/1 | true    |
+      | http://test-data/mobility-hindrances/2/2 | true    |
+      | http://test-data/mobility-hindrances/2/3 | false   |
+      | http://test-data/mobility-hindrances/2/4 | false   |
+      | http://test-data/mobility-hindrances/3/1 | true    |
+      | http://test-data/mobility-hindrances/3/2 | true    |
+      | http://test-data/mobility-hindrances/3/3 | true    |
+      | http://test-data/mobility-hindrances/3/4 | true    |
+      | http://test-data/mobility-hindrances/3/5 | false   |
+
+  Scenario: VERSION-BASED RETENTION
+    When a view with the following properties is created
+      | viewName                          | rdfDescriptionFileName                              |
+      | mobility-hindrances/version-based | retentionpolicy/versionbased/valid_versionbased.ttl |
+    And the following members are allocated to the view "mobility-hindrances/version-based"
+      | http://test-data/mobility-hindrances/1/1 |
+      | http://test-data/mobility-hindrances/1/2 |
+      | http://test-data/mobility-hindrances/2/1 |
+      | http://test-data/mobility-hindrances/2/2 |
+      | http://test-data/mobility-hindrances/2/3 |
+      | http://test-data/mobility-hindrances/2/4 |
+      | http://test-data/mobility-hindrances/3/1 |
+      | http://test-data/mobility-hindrances/3/2 |
+      | http://test-data/mobility-hindrances/3/3 |
+      | http://test-data/mobility-hindrances/3/4 |
+      | http://test-data/mobility-hindrances/3/5 |
+    And wait for 11 seconds until the scheduler has executed at least once
+    Then the following members are deleted
+      | id                                       | deleted |
+      | http://test-data/mobility-hindrances/1/1 | false   |
+      | http://test-data/mobility-hindrances/1/2 | false   |
+      | http://test-data/mobility-hindrances/2/1 | true    |
+      | http://test-data/mobility-hindrances/2/2 | true    |
+      | http://test-data/mobility-hindrances/2/3 | false   |
+      | http://test-data/mobility-hindrances/2/4 | false   |
+      | http://test-data/mobility-hindrances/3/1 | true    |
+      | http://test-data/mobility-hindrances/3/2 | true    |
+      | http://test-data/mobility-hindrances/3/3 | true    |
+      | http://test-data/mobility-hindrances/3/4 | false   |
+      | http://test-data/mobility-hindrances/3/5 | false   |
+
+  Scenario: POINT-IN-TIME RETENTION
+    When a view with the following properties is created
+      | viewName                          | rdfDescriptionFileName                              |
+      | mobility-hindrances/point-in-time | retentionpolicy/pointintime/valid_pointintime.ttl |
+    And the following members are allocated to the view "mobility-hindrances/point-in-time"
+      | http://test-data/mobility-hindrances/1/1 |
+      | http://test-data/mobility-hindrances/1/2 |
+      | http://test-data/mobility-hindrances/2/1 |
+      | http://test-data/mobility-hindrances/2/2 |
+      | http://test-data/mobility-hindrances/2/3 |
+      | http://test-data/mobility-hindrances/2/4 |
+      | http://test-data/mobility-hindrances/3/1 |
+      | http://test-data/mobility-hindrances/3/2 |
+      | http://test-data/mobility-hindrances/3/3 |
+      | http://test-data/mobility-hindrances/3/4 |
+      | http://test-data/mobility-hindrances/3/5 |
+    And wait for 11 seconds until the scheduler has executed at least once
+    Then the following members are deleted
+      | id                                       | deleted |
+      | http://test-data/mobility-hindrances/1/1 | true   |
+      | http://test-data/mobility-hindrances/1/2 | true   |
+      | http://test-data/mobility-hindrances/2/1 | true    |
+      | http://test-data/mobility-hindrances/2/2 | true    |
+      | http://test-data/mobility-hindrances/2/3 | true   |
+      | http://test-data/mobility-hindrances/2/4 | false   |
+      | http://test-data/mobility-hindrances/3/1 | true    |
+      | http://test-data/mobility-hindrances/3/2 | true    |
+      | http://test-data/mobility-hindrances/3/3 | true    |
+      | http://test-data/mobility-hindrances/3/4 | true   |
+      | http://test-data/mobility-hindrances/3/5 | false   |

--- a/ldes-server-retention/src/test/resources/features/retention.feature
+++ b/ldes-server-retention/src/test/resources/features/retention.feature
@@ -5,18 +5,18 @@ Feature: Execute RetentionService
       | collection          | memberType                                                 | timestampPath                             | versionOfPath                        |
       | mobility-hindrances | https://data.vlaanderen.be/ns/mobiliteit#Mobiliteitshinder | http://www.w3.org/ns/prov#generatedAtTime | http://purl.org/dc/terms/isVersionOf |
     And the following Members are ingested
-      | id                                       | collectionName      | versionOf                              | timestamp               |
-      | http://test-data/mobility-hindrances/1/1 | mobility-hindrances | http://test-data/mobility-hindrances/1 | 2013-07-01T00:00:00.000 |
-      | http://test-data/mobility-hindrances/1/2 | mobility-hindrances | http://test-data/mobility-hindrances/1 | 2023-07-02T00:00:00.000 |
-      | http://test-data/mobility-hindrances/2/1 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2013-07-01T00:00:00.000 |
-      | http://test-data/mobility-hindrances/2/2 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2013-07-02T00:00:00.000 |
-      | http://test-data/mobility-hindrances/2/3 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2023-07-03T00:00:00.000 |
-      | http://test-data/mobility-hindrances/2/4 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2023-07-04T00:00:00.000 |
-      | http://test-data/mobility-hindrances/3/1 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-01T00:00:00.000 |
-      | http://test-data/mobility-hindrances/3/2 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-02T00:00:00.000 |
-      | http://test-data/mobility-hindrances/3/3 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-03T00:00:00.000 |
-      | http://test-data/mobility-hindrances/3/4 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-04T00:00:00.000 |
-      | http://test-data/mobility-hindrances/3/5 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2023-07-05T00:00:00.000 |
+      | id                                       | collectionName      | versionOf                              | timestamp               | sequenceNumber |
+      | http://test-data/mobility-hindrances/1/1 | mobility-hindrances | http://test-data/mobility-hindrances/1 | 2013-07-01T00:00:00.000 | 1              |
+      | http://test-data/mobility-hindrances/1/2 | mobility-hindrances | http://test-data/mobility-hindrances/1 | 2023-07-02T00:00:00.000 | 2              |
+      | http://test-data/mobility-hindrances/2/1 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2013-07-01T00:00:00.000 | 3              |
+      | http://test-data/mobility-hindrances/2/2 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2013-07-02T00:00:00.000 | 4              |
+      | http://test-data/mobility-hindrances/2/3 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2023-07-03T00:00:00.000 | 5              |
+      | http://test-data/mobility-hindrances/2/4 | mobility-hindrances | http://test-data/mobility-hindrances/2 | 2023-07-04T00:00:00.000 | 6              |
+      | http://test-data/mobility-hindrances/3/1 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-01T00:00:00.000 | 7              |
+      | http://test-data/mobility-hindrances/3/2 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-02T00:00:00.000 | 8              |
+      | http://test-data/mobility-hindrances/3/3 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-03T00:00:00.000 | 9              |
+      | http://test-data/mobility-hindrances/3/4 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2013-07-04T00:00:00.000 | 10             |
+      | http://test-data/mobility-hindrances/3/5 | mobility-hindrances | http://test-data/mobility-hindrances/3 | 2023-07-05T00:00:00.000 | 11             |
 
   Scenario: TIME-BASED RETENTION
     When a view with the following properties is created
@@ -82,7 +82,7 @@ Feature: Execute RetentionService
 
   Scenario: POINT-IN-TIME RETENTION
     When a view with the following properties is created
-      | viewName                          | rdfDescriptionFileName                              |
+      | viewName                          | rdfDescriptionFileName                            |
       | mobility-hindrances/point-in-time | retentionpolicy/pointintime/valid_pointintime.ttl |
     And the following members are allocated to the view "mobility-hindrances/point-in-time"
       | http://test-data/mobility-hindrances/1/1 |
@@ -99,14 +99,14 @@ Feature: Execute RetentionService
     And wait for 11 seconds until the scheduler has executed at least once
     Then the following members are deleted
       | id                                       | deleted |
-      | http://test-data/mobility-hindrances/1/1 | true   |
-      | http://test-data/mobility-hindrances/1/2 | true   |
+      | http://test-data/mobility-hindrances/1/1 | true    |
+      | http://test-data/mobility-hindrances/1/2 | true    |
       | http://test-data/mobility-hindrances/2/1 | true    |
       | http://test-data/mobility-hindrances/2/2 | true    |
-      | http://test-data/mobility-hindrances/2/3 | true   |
+      | http://test-data/mobility-hindrances/2/3 | true    |
       | http://test-data/mobility-hindrances/2/4 | false   |
       | http://test-data/mobility-hindrances/3/1 | true    |
       | http://test-data/mobility-hindrances/3/2 | true    |
       | http://test-data/mobility-hindrances/3/3 | true    |
-      | http://test-data/mobility-hindrances/3/4 | true   |
+      | http://test-data/mobility-hindrances/3/4 | true    |
       | http://test-data/mobility-hindrances/3/5 | false   |

--- a/ldes-server-retention/src/test/resources/retentionpolicy/pointintime/valid_pointintime.ttl
+++ b/ldes-server-retention/src/test/resources/retentionpolicy/pointintime/valid_pointintime.ttl
@@ -1,4 +1,4 @@
 [ a       <https://w3id.org/ldes#PointInTimePolicy> ;
   <https://w3id.org/ldes#pointInTime>
-          "2023-04-12T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>
+          "2023-07-03T00:00:01"^^<http://www.w3.org/2001/XMLSchema#dateTime>
 ] .

--- a/ldes-server-retention/src/test/resources/retentionpolicy/timebased/valid_timebased.ttl
+++ b/ldes-server-retention/src/test/resources/retentionpolicy/timebased/valid_timebased.ttl
@@ -1,3 +1,3 @@
 [ a                              <https://w3id.org/ldes#DurationAgoPolicy> ;
-  <https://w3id.org/tree#value>  "PT2M"^^<http://www.w3.org/2001/XMLSchema#duration>
+  <https://w3id.org/tree#value>  "P10Y"^^<http://www.w3.org/2001/XMLSchema#duration>
 ] .


### PR DESCRIPTION
Created an integration test for the retention module that acts on the captured events and tests the following policies:
* time-based
* version-based
* point-in-time

On a technical note: It is not possible to capture the outgoing MemberUnallocatedEvents and MemberDeletedEvents, because in the test set-up these are fired in a separate thread (due to the scheduling) and they cannot be captured with the spring test mechanism `ApplicationEvents`, since the test mechanism `ApplicationEventsApplicationListener` is not registered to that thread. Hence, the removal of members from views is verified using the database.