### PR TITLE
fix: replace deprecated jdk in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # INSTALL MAVEN DEPENDENCIES
 #
-FROM maven:3.8.5-openjdk-18 AS builder
+FROM maven:3.8.5-amazoncorretto-17 AS builder
 
 # MAVEN: application
 FROM builder as app-stage
@@ -13,8 +13,8 @@ RUN mvn install -DskipTests
 #
 # RUN THE APPLICATION
 #
-FROM openjdk:18-ea-bullseye
-RUN apt-get update & apt-get upgrade
+FROM amazoncorretto:17-alpine-jdk
+RUN apk update & apk upgrade
 
 COPY --from=app-stage ldes-server-application/target/ldes-server-application.jar ./
 
@@ -40,7 +40,7 @@ COPY --from=app-stage ldes-server-retention/target/ldes-server-retention-jar-wit
 COPY --from=app-stage ldes-server-compaction/target/ldes-server-compaction-jar-with-dependencies.jar ./lib/
 
 
-RUN useradd -u 2000 ldes
+RUN adduser -D -u 2000 ldes
 USER ldes
 
 CMD ["java", "-cp", "ldes-server-application.jar", "-Dloader.path=lib/", "org.springframework.boot.loader.PropertiesLauncher"]


### PR DESCRIPTION
Replaces PR https://github.com/Informatievlaanderen/VSDS-LDESServer4J/pull/492
Fixes https://github.com/Informatievlaanderen/VSDS-LDESServer4J/issues/779

Note that we go from java 18 to java 17. This is because there is only LTS for java 17 and 21 but the server can currently only support up to java 20. We don't lose anything by going "back" to v17