### PR TITLE
fix: slow view operations

### DIFF
--- a/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/config/AsyncConfig.java
+++ b/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.retention.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/services/ViewAddedHandler.java
+++ b/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/services/ViewAddedHandler.java
@@ -2,20 +2,27 @@ package be.vlaanderen.informatievlaanderen.ldes.server.retention.services;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewAddedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.retention.repositories.MemberPropertiesRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ViewAddedHandler {
+	private static final Logger log = LoggerFactory.getLogger(ViewAddedHandler.class);
 	private final MemberPropertiesRepository memberPropertiesRepository;
 
 	public ViewAddedHandler(MemberPropertiesRepository memberPropertiesRepository) {
 		this.memberPropertiesRepository = memberPropertiesRepository;
 	}
 
+	@Async
 	@EventListener
 	public void handle(ViewAddedEvent event) {
+		log.atInfo().log("STARTED adding members to view {} in the background", event.getViewName().asString());
 		memberPropertiesRepository.addViewToAll(event.getViewName());
+		log.atInfo().log("FINISHED adding members to view {} in the background", event.getViewName().asString());
 	}
 
 }

--- a/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/services/ViewAddedHandler.java
+++ b/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/services/ViewAddedHandler.java
@@ -20,9 +20,9 @@ public class ViewAddedHandler {
 	@Async
 	@EventListener
 	public void handle(ViewAddedEvent event) {
-		log.atInfo().log("STARTED adding members to view {} in the background", event.getViewName().asString());
+		log.atInfo().log("STARTED adding existing members to view {} in the background", event.getViewName().asString());
 		memberPropertiesRepository.addViewToAll(event.getViewName());
-		log.atInfo().log("FINISHED adding members to view {} in the background", event.getViewName().asString());
+		log.atInfo().log("FINISHED adding existing members to view {} in the background", event.getViewName().asString());
 	}
 
 }

--- a/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/stub/InMemoryMemberPropertiesRepository.java
+++ b/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/integrationtest/stub/InMemoryMemberPropertiesRepository.java
@@ -9,6 +9,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.retention.services.retenti
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -96,7 +97,7 @@ public class InMemoryMemberPropertiesRepository implements MemberPropertiesRepos
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/2"),
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/3"),
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/4")
-        );
+        ).filter(Objects::nonNull);
     }
 
     @Override
@@ -109,7 +110,7 @@ public class InMemoryMemberPropertiesRepository implements MemberPropertiesRepos
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/1"),
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/2"),
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/3")
-        );
+        ).filter(Objects::nonNull);
     }
 
     @Override
@@ -123,6 +124,6 @@ public class InMemoryMemberPropertiesRepository implements MemberPropertiesRepos
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/2"),
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/3"),
                 memberPropertiesMap.get("http://test-data/mobility-hindrances/3/4")
-        );
+        ).filter(Objects::nonNull);
     }
 }


### PR DESCRIPTION
When a view is added or deleted to a collection with a large amount of members, it takes forever to perform this action, due to the allocation and unallocation of members to a view. This is now made asynchronous