### PR TITLE
fix: members deleted twice

### DIFF
--- a/ldes-server-admin/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/domain/view/repository/DcatViewRepository.java
+++ b/ldes-server-admin/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/domain/view/repository/DcatViewRepository.java
@@ -8,12 +8,14 @@ import java.util.Optional;
 
 public interface DcatViewRepository {
 
-	void save(DcatView dcatView);
+    void save(DcatView dcatView);
 
-	Optional<DcatView> findByViewName(ViewName viewName);
+    Optional<DcatView> findByViewName(ViewName viewName);
 
-	void delete(ViewName viewName);
+    void delete(ViewName viewName);
 
-	List<DcatView> findAll();
+    void deleteByCollectionName(String collectionName);
+
+    List<DcatView> findAll();
 
 }

--- a/ldes-server-admin/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/domain/view/service/DcatViewServiceImpl.java
+++ b/ldes-server-admin/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/domain/view/service/DcatViewServiceImpl.java
@@ -3,6 +3,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.admin.domain.view.service
 import be.vlaanderen.informatievlaanderen.ldes.server.admin.domain.view.repository.DcatViewRepository;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.DcatViewDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.DcatViewSavedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.EventStreamDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingResourceException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.DcatView;
@@ -64,6 +65,11 @@ public class DcatViewServiceImpl implements DcatViewService {
 	@EventListener
 	public void handleViewDeletedEvent(ViewDeletedEvent event) {
 		delete(event.getViewName());
+	}
+
+	@EventListener
+	public void handleEventStreamDeletedEvent(EventStreamDeletedEvent event) {
+		dcatViewRepository.deleteByCollectionName(event.collectionName());
 	}
 
 	/**

--- a/ldes-server-admin/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/domain/view/service/ViewServiceImpl.java
+++ b/ldes-server-admin/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/domain/view/service/ViewServiceImpl.java
@@ -110,6 +110,7 @@ public class ViewServiceImpl implements ViewService {
             throw new MissingResourceException(EVENT_STREAM_TYPE, viewName.getCollectionName());
         }
 
+        eventPublisher.publishEvent(new ViewDeletedEvent(viewName));
         deleteAllViewsByViewName(List.of(viewName));
     }
 
@@ -118,7 +119,6 @@ public class ViewServiceImpl implements ViewService {
         viewNames.forEach(viewName -> {
             log.atInfo().log("START deleting view  {}", viewName.asString());
             viewRepository.deleteViewByViewName(viewName);
-            eventPublisher.publishEvent(new ViewDeletedEvent(viewName));
             log.atInfo().log("FINISHED deleting view {}", viewName.asString());
         });
     }

--- a/ldes-server-admin/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/domain/view/service/ViewServiceImplTest.java
+++ b/ldes-server-admin/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/domain/view/service/ViewServiceImplTest.java
@@ -141,8 +141,8 @@ class ViewServiceImplTest {
 			viewService.deleteViewByViewName(viewName);
 
 			InOrder inOrder = inOrder(viewRepository, eventPublisher, dcatViewService);
-			inOrder.verify(viewRepository).deleteViewByViewName(viewName);
 			inOrder.verify(eventPublisher).publishEvent(any(ViewDeletedEvent.class));
+			inOrder.verify(viewRepository).deleteViewByViewName(viewName);
 			inOrder.verifyNoMoreInteractions();
 		}
 	}
@@ -239,7 +239,6 @@ class ViewServiceImplTest {
 
 		viewService.handleEventStreamDeletedEvent(new EventStreamDeletedEvent(COLLECTION));
 
-		verify(eventPublisher, times(2)).publishEvent(any(ViewDeletedEvent.class));
 		verify(viewRepository).deleteViewByViewName(view);
 		verify(viewRepository).deleteViewByViewName(view2);
 		assertThatThrownBy(() -> viewService.getViewsByCollectionName(COLLECTION))

--- a/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/application/eventhandlers/ViewCapacityDeleter.java
+++ b/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/application/eventhandlers/ViewCapacityDeleter.java
@@ -21,7 +21,7 @@ public class ViewCapacityDeleter {
 
 	@EventListener
 	public void handleEventStreamDeletedEvent(EventStreamDeletedEvent event) {
-		viewCollection.deleteViewCapacitiesByViewName(event.collectionName());
+		viewCollection.deleteViewCapacitiesByCollectionName(event.collectionName());
 	}
 
 }

--- a/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/application/eventhandlers/ViewCapacityDeleter.java
+++ b/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/application/eventhandlers/ViewCapacityDeleter.java
@@ -1,6 +1,7 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.compaction.application.eventhandlers;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.compaction.domain.repository.ViewCollection;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.EventStreamDeletedEvent;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewDeletedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,11 @@ public class ViewCapacityDeleter {
 	@EventListener
 	public void handleViewDeletedEvent(ViewDeletedEvent event) {
 		viewCollection.deleteViewCapacityByViewName(event.getViewName());
+	}
+
+	@EventListener
+	public void handleEventStreamDeletedEvent(EventStreamDeletedEvent event) {
+		viewCollection.deleteViewCapacitiesByViewName(event.collectionName());
 	}
 
 }

--- a/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollection.java
+++ b/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollection.java
@@ -10,7 +10,7 @@ public interface ViewCollection {
 
 	void deleteViewCapacityByViewName(ViewName viewName);
 
-	void deleteViewCapacitiesByViewName(String collectionName);
+	void deleteViewCapacitiesByCollectionName(String collectionName);
 
 	Collection<ViewCapacity> getAllViewCapacities();
 }

--- a/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollection.java
+++ b/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollection.java
@@ -8,9 +8,9 @@ import java.util.Collection;
 public interface ViewCollection {
 	void saveViewCapacity(ViewCapacity viewCapacity);
 
-	ViewCapacity getViewCapacityByViewName(ViewName viewName);
-
 	void deleteViewCapacityByViewName(ViewName viewName);
+
+	void deleteViewCapacitiesByViewName(String collectionName);
 
 	Collection<ViewCapacity> getAllViewCapacities();
 }

--- a/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollectionImpl.java
+++ b/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollectionImpl.java
@@ -10,25 +10,28 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 public class ViewCollectionImpl implements ViewCollection {
-	private final Map<ViewName, ViewCapacity> viewCapacities = new ConcurrentHashMap<>();
+    private final Map<ViewName, ViewCapacity> viewCapacities = new ConcurrentHashMap<>();
 
-	@Override
-	public void saveViewCapacity(ViewCapacity viewCapacity) {
-		viewCapacities.put(viewCapacity.getViewName(), viewCapacity);
-	}
+    @Override
+    public void saveViewCapacity(ViewCapacity viewCapacity) {
+        viewCapacities.put(viewCapacity.getViewName(), viewCapacity);
+    }
 
-	@Override
-	public ViewCapacity getViewCapacityByViewName(ViewName viewName) {
-		return viewCapacities.get(viewName);
-	}
+    @Override
+    public void deleteViewCapacityByViewName(ViewName viewName) {
+        viewCapacities.remove(viewName);
+    }
 
-	@Override
-	public void deleteViewCapacityByViewName(ViewName viewName) {
-		viewCapacities.remove(viewName);
-	}
+    @Override
+    public void deleteViewCapacitiesByViewName(String collectionName) {
+        viewCapacities.keySet().stream()
+                .filter(viewName -> viewName.getCollectionName().equals(collectionName))
+                .toList()
+                .forEach(viewCapacities::remove);
+    }
 
-	@Override
-	public Collection<ViewCapacity> getAllViewCapacities() {
-		return viewCapacities.values();
-	}
+    @Override
+    public Collection<ViewCapacity> getAllViewCapacities() {
+        return viewCapacities.values();
+    }
 }

--- a/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollectionImpl.java
+++ b/ldes-server-compaction/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollectionImpl.java
@@ -23,7 +23,7 @@ public class ViewCollectionImpl implements ViewCollection {
     }
 
     @Override
-    public void deleteViewCapacitiesByViewName(String collectionName) {
+    public void deleteViewCapacitiesByCollectionName(String collectionName) {
         viewCapacities.keySet().stream()
                 .filter(viewName -> viewName.getCollectionName().equals(collectionName))
                 .toList()

--- a/ldes-server-compaction/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollectionImplTest.java
+++ b/ldes-server-compaction/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/compaction/domain/repository/ViewCollectionImplTest.java
@@ -1,0 +1,51 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.compaction.domain.repository;
+
+import be.vlaanderen.informatievlaanderen.ldes.server.compaction.domain.entities.ViewCapacity;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.ViewName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ViewCollectionImplTest {
+    private static final String COLLECTION = "collection";
+    private ViewCollection viewCollection;
+
+    @BeforeEach
+    void setUp() {
+        viewCollection = new ViewCollectionImpl();
+    }
+
+    @Test
+    void test_deleteByViewName() {
+        final String viewNameToDelete = "view1";
+        final String viewNameToKeep = "view2";
+        Stream.of(viewNameToDelete, viewNameToKeep)
+                .map(viewName -> new ViewName(COLLECTION, viewName))
+                .map(viewName -> new ViewCapacity(viewName, 100))
+                .forEach(viewCollection::saveViewCapacity);
+
+        viewCollection.deleteViewCapacityByViewName(new ViewName(COLLECTION, viewNameToDelete));
+
+        assertThat(viewCollection.getAllViewCapacities())
+                .map(ViewCapacity::getViewName)
+                .containsExactlyInAnyOrder(new ViewName(COLLECTION, viewNameToKeep));
+    }
+    @Test
+    void test_deleteByCollectionName() {
+        final ViewName viewNameToKeep = new ViewName("collection-to-keep", "view1");
+        Stream.of("view1", "view2", "view3")
+                .map(viewName -> new ViewName(COLLECTION, viewName))
+                .map(viewName -> new ViewCapacity(viewName, 100))
+                .forEach(viewCollection::saveViewCapacity);
+        viewCollection.saveViewCapacity(new ViewCapacity(viewNameToKeep, 100));
+
+        viewCollection.deleteViewCapacitiesByCollectionName(COLLECTION);
+
+        assertThat(viewCollection.getAllViewCapacities())
+                .map(ViewCapacity::getViewName)
+                .containsExactlyInAnyOrder(viewNameToKeep);
+    }
+}

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/MongoAdminAutoConfiguration.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/MongoAdminAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
 @Configuration
 @EnableConfigurationProperties()
@@ -65,8 +66,8 @@ public class MongoAdminAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public DcatViewRepository dcatViewMongoRepository(final DataServiceEntityRepository dataServiceEntityRepository) {
-		return new DcatViewMongoRepository(dataServiceEntityRepository, new DcatServiceEntityConverter());
+	public DcatViewRepository dcatViewMongoRepository(final DataServiceEntityRepository dataServiceEntityRepository, final MongoTemplate mongoTemplate) {
+		return new DcatViewMongoRepository(dataServiceEntityRepository, new DcatServiceEntityConverter(), mongoTemplate);
 	}
 
 }

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/DcatViewMongoRepository.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/DcatViewMongoRepository.java
@@ -39,6 +39,11 @@ public class DcatViewMongoRepository implements DcatViewRepository {
 	}
 
 	@Override
+	public void deleteByCollectionName(String collectionName) {
+		dataServiceEntityRepository.deleteAllByCollectionName(collectionName);
+	}
+
+	@Override
 	public List<DcatView> findAll() {
 		return dataServiceEntityRepository.findAll().stream().map(dcatServiceEntityConverter::toDcatView).toList();
 	}

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/DcatViewMongoRepository.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/DcatViewMongoRepository.java
@@ -6,46 +6,55 @@ import be.vlaanderen.informatievlaanderen.ldes.server.admin.mongo.view.repositor
 import be.vlaanderen.informatievlaanderen.ldes.server.admin.mongo.view.service.DcatServiceEntityConverter;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.DcatView;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.ViewName;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public class DcatViewMongoRepository implements DcatViewRepository {
 
-	private final DataServiceEntityRepository dataServiceEntityRepository;
-	private final DcatServiceEntityConverter dcatServiceEntityConverter;
+    private final DataServiceEntityRepository dataServiceEntityRepository;
+    private final DcatServiceEntityConverter dcatServiceEntityConverter;
+    private final MongoTemplate mongoTemplate;
 
-	public DcatViewMongoRepository(DataServiceEntityRepository dataServiceEntityRepository,
-			DcatServiceEntityConverter dcatServiceEntityConverter) {
-		this.dataServiceEntityRepository = dataServiceEntityRepository;
-		this.dcatServiceEntityConverter = dcatServiceEntityConverter;
-	}
 
-	@Override
-	public void save(DcatView dcatView) {
-		DataServiceEntity dataServiceEntity = dcatServiceEntityConverter.fromDcatView(dcatView);
-		dataServiceEntityRepository.save(dataServiceEntity);
-	}
+    public DcatViewMongoRepository(DataServiceEntityRepository dataServiceEntityRepository,
+                                   DcatServiceEntityConverter dcatServiceEntityConverter, MongoTemplate mongoTemplate) {
+        this.dataServiceEntityRepository = dataServiceEntityRepository;
+        this.dcatServiceEntityConverter = dcatServiceEntityConverter;
+        this.mongoTemplate = mongoTemplate;
+    }
 
-	@Override
-	public Optional<DcatView> findByViewName(ViewName viewName) {
-		return dataServiceEntityRepository.findById(viewName.asString())
-				.map(dcatServiceEntityConverter::toDcatView);
-	}
+    @Override
+    public void save(DcatView dcatView) {
+        DataServiceEntity dataServiceEntity = dcatServiceEntityConverter.fromDcatView(dcatView);
+        dataServiceEntityRepository.save(dataServiceEntity);
+    }
 
-	@Override
-	public void delete(ViewName viewName) {
-		dataServiceEntityRepository.deleteById(viewName.asString());
-	}
+    @Override
+    public Optional<DcatView> findByViewName(ViewName viewName) {
+        return dataServiceEntityRepository.findById(viewName.asString())
+                .map(dcatServiceEntityConverter::toDcatView);
+    }
 
-	@Override
-	public void deleteByCollectionName(String collectionName) {
-		dataServiceEntityRepository.deleteAllByCollectionName(collectionName);
-	}
+    @Override
+    public void delete(ViewName viewName) {
+        dataServiceEntityRepository.deleteById(viewName.asString());
+    }
 
-	@Override
-	public List<DcatView> findAll() {
-		return dataServiceEntityRepository.findAll().stream().map(dcatServiceEntityConverter::toDcatView).toList();
-	}
+    @Override
+    public void deleteByCollectionName(String collectionName) {
+        final Query query = new Query();
+        query.addCriteria(Criteria.where("_id").regex("^" + collectionName + "/"));
+
+        mongoTemplate.remove(query, DataServiceEntity.class);
+    }
+
+    @Override
+    public List<DcatView> findAll() {
+        return dataServiceEntityRepository.findAll().stream().map(dcatServiceEntityConverter::toDcatView).toList();
+    }
 
 }

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/repository/DataServiceEntityRepository.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/repository/DataServiceEntityRepository.java
@@ -2,9 +2,6 @@ package be.vlaanderen.informatievlaanderen.ldes.server.admin.mongo.view.reposito
 
 import be.vlaanderen.informatievlaanderen.ldes.server.admin.mongo.view.entity.DataServiceEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 
 public interface DataServiceEntityRepository extends MongoRepository<DataServiceEntity, String> {
-    @Query(value = "{'_id':  {$regex:  ?0}}", delete = true)
-    void deleteAllByCollectionName(String collectionName);
 }

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/repository/DataServiceEntityRepository.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/repository/DataServiceEntityRepository.java
@@ -2,6 +2,9 @@ package be.vlaanderen.informatievlaanderen.ldes.server.admin.mongo.view.reposito
 
 import be.vlaanderen.informatievlaanderen.ldes.server.admin.mongo.view.entity.DataServiceEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 public interface DataServiceEntityRepository extends MongoRepository<DataServiceEntity, String> {
+    @Query("{'_id':  {$regex:  ?0}}")
+    void deleteAllByCollectionName(String collectionName);
 }

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/repository/DataServiceEntityRepository.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/repository/DataServiceEntityRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 public interface DataServiceEntityRepository extends MongoRepository<DataServiceEntity, String> {
-    @Query("{'_id':  {$regex:  ?0}}")
+    @Query(value = "{'_id':  {$regex:  ?0}}", delete = true)
     void deleteAllByCollectionName(String collectionName);
 }

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/SpringIntegrationTest.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/SpringIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -33,14 +34,16 @@ public class SpringIntegrationTest {
 	public DcatServerMongoRepository serverDcatMongoRepository;
 	@Autowired
 	public DcatViewMongoRepository dcatViewMongoRepository;
+	@Autowired
+	public MongoTemplate mongoTemplate;
 
 	@TestConfiguration
 	public static class EventStreamControllerTestConfiguration {
 
 		@Bean
 		public DcatViewRepository dcatViewMongoRepository(
-				final DataServiceEntityRepository dataServiceEntityRepository) {
-			return new DcatViewMongoRepository(dataServiceEntityRepository, new DcatServiceEntityConverter());
+				final DataServiceEntityRepository dataServiceEntityRepository, final MongoTemplate mongoTemplate) {
+			return new DcatViewMongoRepository(dataServiceEntityRepository, new DcatServiceEntityConverter(), mongoTemplate);
 		}
 
 		@Bean

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/DcatViewRepositorySteps.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/DcatViewRepositorySteps.java
@@ -6,6 +6,7 @@ import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.ViewName;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParser;
@@ -84,5 +85,10 @@ public class DcatViewRepositorySteps extends SpringIntegrationTest {
 		List<String> views = dcatViews.stream().map(DcatView::getViewName).map(ViewName::getViewName).toList();
 		assertTrue(views.contains("view1"));
 		assertTrue(views.contains("view2"));
+	}
+
+	@When("I delete the corresponding eventstream")
+	public void iDeleteTheCorrespondingEventstream() {
+		dcatViewMongoRepository.deleteByCollectionName(COLLECTION_NAME);
 	}
 }

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/DcatViewRepositorySteps.java
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/mongo/view/DcatViewRepositorySteps.java
@@ -17,102 +17,96 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DcatViewRepositorySteps extends SpringIntegrationTest {
 
-	private final static String COLLECTION_NAME = "collectionName";
-	private final static String VIEW = "view";
-	private final static ViewName VIEW_NAME = new ViewName(COLLECTION_NAME, VIEW);
-	private Model model;
+    private final static String COLLECTION_NAME = "collectionName";
+    private final static String VIEW = "view";
+    private final static ViewName VIEW_NAME = new ViewName(COLLECTION_NAME, VIEW);
+    private Model model;
 
-	private DcatView dcatView;
-	private DcatView resultDcatView;
+    private DcatView dcatView;
+    private DcatView resultDcatView;
 
-	@Before
-	public void teardown() {
-		dcatViewMongoRepository.findAll().stream().map(DcatView::getViewName).forEach(dcatViewMongoRepository::delete);
-	}
+    @Before
+    public void teardown() {
+        dcatViewMongoRepository.findAll().stream().map(DcatView::getViewName).forEach(dcatViewMongoRepository::delete);
+    }
 
-	@Given("I have a dcatView with a viewName and model")
-	public void giveIHaveADcatView() {
-		model = RDFParser.source("features/view/dataservice.ttl").lang(Lang.TURTLE).build().toModel();
-		dcatView = DcatView.from(VIEW_NAME, model);
-	}
+    @Given("I have a dcatView with a viewName and model")
+    public void giveIHaveADcatView() {
+        model = RDFParser.source("features/view/dataservice.ttl").lang(Lang.TURTLE).build().toModel();
+        dcatView = DcatView.from(VIEW_NAME, model);
+    }
 
-	@Then("I can update the dcatView with a new model")
-	public void iCanUpdateTheDcatViewWithANewModel() {
-		model = RDFParser.source("features/view/dataservice2.ttl").lang(Lang.TURTLE).build().toModel();
-		dcatView = DcatView.from(VIEW_NAME, model);
-		dcatViewMongoRepository.save(dcatView);
-	}
+    @Then("I can update the dcatView with a new model")
+    public void iCanUpdateTheDcatViewWithANewModel() {
+        model = RDFParser.source("features/view/dataservice2.ttl").lang(Lang.TURTLE).build().toModel();
+        dcatView = DcatView.from(VIEW_NAME, model);
+        dcatViewMongoRepository.save(dcatView);
+    }
 
-	@And("I can save the dcatView with the repository")
-	public void iSaveTheDcatViewWithTheRepository() {
-		dcatViewMongoRepository.save(dcatView);
-	}
+    @And("I can save the dcatView with the repository")
+    public void iSaveTheDcatViewWithTheRepository() {
+        dcatViewMongoRepository.save(dcatView);
+    }
 
-	@Then("I can retrieve the dcatView from the repository")
-	public void iCanRetrieveTheDcatViewFromTheRepository() {
-		Optional<DcatView> dcatViewOpt = dcatViewMongoRepository.findByViewName(VIEW_NAME);
-		assertTrue(dcatViewOpt.isPresent());
-		resultDcatView = dcatViewOpt.get();
-	}
+    @Then("I can retrieve the dcatView from the repository")
+    public void iCanRetrieveTheDcatViewFromTheRepository() {
+        Optional<DcatView> dcatViewOpt = dcatViewMongoRepository.findByViewName(VIEW_NAME);
+        assertThat(dcatViewOpt).isPresent();
+        resultDcatView = dcatViewOpt.get();
+    }
 
 	@And("The retrieved dcatView will be the same as the saved dcatView")
 	public void theRetrievedDcatViewWillBeTheSameAsTheSavedDcatView() {
-		assertTrue(dcatView.getDcat().isIsomorphicWith(resultDcatView.getDcat()));
-		assertEquals(dcatView.getViewName(), resultDcatView.getViewName());
+        assertThat(dcatView.getDcat()).matches(actualDcat -> resultDcatView.getDcat().isIsomorphicWith(actualDcat));
+        assertThat(dcatView.getViewName()).isEqualTo(resultDcatView.getViewName());
 	}
 
-	@Then("I can delete the dcatView")
-	public void iCanDeleteTheDcatView() {
-		dcatViewMongoRepository.delete(VIEW_NAME);
-	}
+    @Then("I can delete the dcatView")
+    public void iCanDeleteTheDcatView() {
+        dcatViewMongoRepository.delete(VIEW_NAME);
+    }
 
-	@And("I can not retrieve the dcatView from the repository")
-	public void iCanNotRetrieveTheDcatViewFromTheRepository() {
-		Optional<DcatView> dcatViewOpt = dcatViewMongoRepository.findByViewName(VIEW_NAME);
-		assertTrue(dcatViewOpt.isEmpty());
-	}
+    @And("I can not retrieve the dcatView from the repository")
+    public void iCanNotRetrieveTheDcatViewFromTheRepository() {
+        Optional<DcatView> dcatViewOpt = dcatViewMongoRepository.findByViewName(VIEW_NAME);
+        assertThat(dcatViewOpt).isEmpty();
+    }
 
-	@Given("the database contains multiple dcatViews")
-	public void theDatabaseContainsMultipleDcatViews() {
-		Model model1 = RDFParser.source("features/view/dataservice.ttl").lang(Lang.TURTLE).build().toModel();
-		Model model2 = RDFParser.source("features/view/dataservice2.ttl").lang(Lang.TURTLE).build().toModel();
-		dcatViewMongoRepository.save(DcatView.from(new ViewName("col1", "view1"), model1));
-		dcatViewMongoRepository.save(DcatView.from(new ViewName("col1", "view2"), model2));
-	}
+    @Given("the database contains multiple dcatViews")
+    public void theDatabaseContainsMultipleDcatViews() {
+        Model model1 = RDFParser.source("features/view/dataservice.ttl").lang(Lang.TURTLE).build().toModel();
+        Model model2 = RDFParser.source("features/view/dataservice2.ttl").lang(Lang.TURTLE).build().toModel();
+        dcatViewMongoRepository.save(DcatView.from(new ViewName("col1", "view1"), model1));
+        dcatViewMongoRepository.save(DcatView.from(new ViewName("col1", "view2"), model2));
+    }
 
-	@Then("I can find all dcatViews")
-	public void iCanFindAllDcatViews() {
-		List<DcatView> dcatViews = dcatViewMongoRepository.findAll();
-		assertEquals(2, dcatViews.size());
+    @Then("I can find all dcatViews")
+    public void iCanFindAllDcatViews() {
+        List<DcatView> dcatViews = dcatViewMongoRepository.findAll();
 
-		List<String> views = dcatViews.stream().map(DcatView::getViewName).map(ViewName::getViewName).toList();
-		assertTrue(views.contains("view1"));
-		assertTrue(views.contains("view2"));
-	}
+        assertThat(dcatViews)
+                .hasSize(2)
+                .map(DcatView::getViewName)
+                .map(ViewName::getViewName)
+                .containsExactlyInAnyOrder("view1", "view2");
+    }
 
-	@When("I delete the corresponding eventstream")
-	public void iDeleteTheCorrespondingEventstream() {
-		dcatViewMongoRepository.deleteByCollectionName(COLLECTION_NAME);
-	}
+    @When("I delete the corresponding eventstream")
+    public void iDeleteTheCorrespondingEventstream() {
+        dcatViewMongoRepository.deleteByCollectionName(COLLECTION_NAME);
+    }
 
-	@And("I have a second dcatView with a viewName and model")
-	public void iHaveASecondDcatViewWithAViewNameAndModel() {
-		dcatView = DcatView.from(VIEW_NAME, model);
-	}
+    @And("the database already contains another dcatView")
+    public void theDatabaseAlreadyContainsAnotherDcatView() {
+        final var otherDcatView = DcatView.from(new ViewName("other-" + COLLECTION_NAME, VIEW), ModelFactory.createDefaultModel());
+        dcatViewMongoRepository.save(otherDcatView);
+    }
 
-	@And("the database already contains another dcatView")
-	public void theDatabaseAlreadyContainsAnotherDcatView() {
-		final var otherDcatView = DcatView.from(new ViewName("other-" + COLLECTION_NAME, VIEW), ModelFactory.createDefaultModel());
-		dcatViewMongoRepository.save(otherDcatView);
-	}
-
-	@Then("the repository contains exactly {int} dcatViews")
-	public void theRepositoryContainsExactlyDcatView(int expectedNumberOfDcatViews) {
-		assertThat(dcatViewMongoRepository.findAll()).hasSize(expectedNumberOfDcatViews);
-	}
+    @Then("the repository contains exactly {int} dcatViews")
+    public void theRepositoryContainsExactlyDcatView(int expectedNumberOfDcatViews) {
+        assertThat(dcatViewMongoRepository.findAll()).hasSize(expectedNumberOfDcatViews);
+    }
 }

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/test/resources/features/view/dcatview.feature
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/test/resources/features/view/dcatview.feature
@@ -19,6 +19,8 @@ Feature: DcatViewRepository
 
   Scenario: A dcatView is deleted when the eventstream is deleted
     Given I have a dcatView with a viewName and model
-    Then I can save the dcatView with the repository
+    And the database already contains another dcatView
+    When I can save the dcatView with the repository
+    Then the repository contains exactly 2 dcatViews
     When I delete the corresponding eventstream
-    Then I can not retrieve the dcatView from the repository
+    Then the repository contains exactly 1 dcatViews

--- a/ldes-server-infra-mongo/mongo-admin-repository/src/test/resources/features/view/dcatview.feature
+++ b/ldes-server-infra-mongo/mongo-admin-repository/src/test/resources/features/view/dcatview.feature
@@ -17,3 +17,8 @@ Feature: DcatViewRepository
     Given the database contains multiple dcatViews
     Then I can find all dcatViews
 
+  Scenario: A dcatView is deleted when the eventstream is deleted
+    Given I have a dcatView with a viewName and model
+    Then I can save the dcatView with the repository
+    When I delete the corresponding eventstream
+    Then I can not retrieve the dcatView from the repository

--- a/ldes-server-infra-mongo/mongo-fetch-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/fetch/AllocationMongoRepository.java
+++ b/ldes-server-infra-mongo/mongo-fetch-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/fetch/AllocationMongoRepository.java
@@ -96,6 +96,7 @@ public class AllocationMongoRepository implements AllocationRepository {
 		return mongoTemplate.aggregateStream(aggregation, FETCH_ALLOCATION, CompactionCandidate.class);
 	}
 
+	@Override
 	public void deleteByCollectionName(String collectionName) {
 		repository.deleteAllByCollectionName(collectionName);
 	}

--- a/ldes-server-port-fetch-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImpl.java
+++ b/ldes-server-port-fetch-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImpl.java
@@ -2,6 +2,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.rest.treenode.services;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.PrefixAdder;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.*;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingResourceException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.DcatView;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.EventStream;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.ViewName;
@@ -54,6 +55,9 @@ public class TreeNodeConverterImpl implements TreeNodeConverter {
 
     private List<Statement> addTreeNodeStatements(TreeNode treeNode, String collectionName, String prefix) {
         EventStream eventStream = eventStreams.get(collectionName);
+        if(eventStream == null) {
+            throw new MissingResourceException("eventstream", collectionName);
+        }
         Model shaclShape = shaclShapes.get(collectionName);
         List<TreeRelationResponse> treeRelationResponses = treeNode.getRelations().stream()
                 .map(treeRelation -> new TreeRelationResponse(treeRelation.treePath(),

--- a/ldes-server-port-fetch-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImpl.java
+++ b/ldes-server-port-fetch-rest/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImpl.java
@@ -24,128 +24,133 @@ import static org.apache.jena.rdf.model.ResourceFactory.createStatement;
 @Component
 public class TreeNodeConverterImpl implements TreeNodeConverter {
 
-	private final PrefixAdder prefixAdder;
-	private final PrefixConstructor prefixConstructor;
+    private final PrefixAdder prefixAdder;
+    private final PrefixConstructor prefixConstructor;
 
-	private final Map<ViewName, DcatView> dcatViews = new HashMap<>();
-	private final Map<String, EventStream> eventStreams = new HashMap<>();
-	private final Map<String, Model> shaclShapes = new HashMap<>();
+    private final Map<ViewName, DcatView> dcatViews = new HashMap<>();
+    private final Map<String, EventStream> eventStreams = new HashMap<>();
+    private final Map<String, Model> shaclShapes = new HashMap<>();
 
-	public TreeNodeConverterImpl(PrefixAdder prefixAdder, PrefixConstructor prefixConstructor) {
-		this.prefixAdder = prefixAdder;
-		this.prefixConstructor = prefixConstructor;
-	}
+    public TreeNodeConverterImpl(PrefixAdder prefixAdder, PrefixConstructor prefixConstructor) {
+        this.prefixAdder = prefixAdder;
+        this.prefixConstructor = prefixConstructor;
+    }
 
-	@Override
-	public Model toModel(final TreeNode treeNode) {
-		String prefix = prefixConstructor.buildPrefix();
-		Model model = ModelFactory.createDefaultModel()
-				.add(addTreeNodeStatements(treeNode, treeNode.getCollectionName(), prefix));
+    @Override
+    public Model toModel(final TreeNode treeNode) {
+        String prefix = prefixConstructor.buildPrefix();
+        Model model = ModelFactory.createDefaultModel()
+                .add(addTreeNodeStatements(treeNode, treeNode.getCollectionName(), prefix));
 
-		if (!treeNode.getMembers().isEmpty()) {
-			String baseUrl = prefix + "/" + treeNode.getCollectionName();
-			model.add(addEventStreamStatements(treeNode, baseUrl));
-			treeNode.getMembers().stream()
-					.map(Member::model).forEach(model::add);
-		}
+        if (!treeNode.getMembers().isEmpty()) {
+            String baseUrl = prefix + "/" + treeNode.getCollectionName();
+            model.add(addEventStreamStatements(treeNode, baseUrl));
+            treeNode.getMembers().stream()
+                    .map(Member::model).forEach(model::add);
+        }
 
-		return prefixAdder.addPrefixesToModel(model);
-	}
+        return prefixAdder.addPrefixesToModel(model);
+    }
 
-	private List<Statement> addTreeNodeStatements(TreeNode treeNode, String collectionName, String prefix) {
-		EventStream eventStream = eventStreams.get(collectionName);
-		Model shaclShape = shaclShapes.get(collectionName);
-		List<TreeRelationResponse> treeRelationResponses = treeNode.getRelations().stream()
-				.map(treeRelation -> new TreeRelationResponse(treeRelation.treePath(),
-						prefix + treeRelation.treeNode().asEncodedFragmentId(),
-						treeRelation.treeValue(), treeRelation.treeValueType(), treeRelation.relation()))
-				.toList();
-		TreeNodeInfoResponse treeNodeInfoResponse = new TreeNodeInfoResponse(treeNode.getFragmentId(),
-				treeRelationResponses);
-		List<Statement> statements = new ArrayList<>(treeNodeInfoResponse.convertToStatements());
-		addLdesCollectionStatements(statements, treeNode.isView(), treeNode.getFragmentId(), eventStream, shaclShape, prefix);
+    private List<Statement> addTreeNodeStatements(TreeNode treeNode, String collectionName, String prefix) {
+        EventStream eventStream = eventStreams.get(collectionName);
+        Model shaclShape = shaclShapes.get(collectionName);
+        List<TreeRelationResponse> treeRelationResponses = treeNode.getRelations().stream()
+                .map(treeRelation -> new TreeRelationResponse(treeRelation.treePath(),
+                        prefix + treeRelation.treeNode().asEncodedFragmentId(),
+                        treeRelation.treeValue(), treeRelation.treeValueType(), treeRelation.relation()))
+                .toList();
+        TreeNodeInfoResponse treeNodeInfoResponse = new TreeNodeInfoResponse(treeNode.getFragmentId(),
+                treeRelationResponses);
+        List<Statement> statements = new ArrayList<>(treeNodeInfoResponse.convertToStatements());
+        addLdesCollectionStatements(statements, treeNode.isView(), treeNode.getFragmentId(), eventStream, shaclShape, prefix);
 
-		return statements;
-	}
+        return statements;
+    }
 
-	private void addLdesCollectionStatements(List<Statement> statements, boolean isView, String currentFragmentId,
-			EventStream eventStream, Model shaclShape, String prefix) {
-		String baseUrl = prefix + "/" + eventStream.getCollection();
-		Resource collection = createResource(baseUrl);
+    private void addLdesCollectionStatements(List<Statement> statements, boolean isView, String currentFragmentId,
+                                             EventStream eventStream, Model shaclShape, String prefix) {
+        String baseUrl = prefix + "/" + eventStream.getCollection();
+        Resource collection = createResource(baseUrl);
 
-		if (isView) {
-			EventStreamInfoResponse eventStreamInfoResponse = new EventStreamInfoResponse(
-					baseUrl,
-					eventStream.getTimestampPath(),
-					eventStream.getVersionOfPath(),
-					shaclShape,
-					Collections.singletonList(currentFragmentId));
-			statements.addAll(eventStreamInfoResponse.convertToStatements());
-			addDcatStatements(statements, currentFragmentId, eventStream.getCollection(), prefix);
-		} else {
-			statements.add(createStatement(createResource(currentFragmentId), IS_PART_OF_PROPERTY, collection));
-		}
-	}
+        if (isView) {
+            EventStreamInfoResponse eventStreamInfoResponse = new EventStreamInfoResponse(
+                    baseUrl,
+                    eventStream.getTimestampPath(),
+                    eventStream.getVersionOfPath(),
+                    shaclShape,
+                    Collections.singletonList(currentFragmentId));
+            statements.addAll(eventStreamInfoResponse.convertToStatements());
+            addDcatStatements(statements, currentFragmentId, eventStream.getCollection(), prefix);
+        } else {
+            statements.add(createStatement(createResource(currentFragmentId), IS_PART_OF_PROPERTY, collection));
+        }
+    }
 
-	private void addDcatStatements(List<Statement> statements, String currentFragmentId, String collection, String prefix) {
-		ViewName viewName = ViewName.fromString(currentFragmentId.substring(currentFragmentId.indexOf(collection)));
-		DcatView dcatView = dcatViews.get(viewName);
-		if (dcatView != null) {
-			statements.addAll(dcatView.getStatementsWithBase(prefix));
-		}
-	}
+    private void addDcatStatements(List<Statement> statements, String currentFragmentId, String collection, String prefix) {
+        ViewName viewName = ViewName.fromString(currentFragmentId.substring(currentFragmentId.indexOf(collection)));
+        DcatView dcatView = dcatViews.get(viewName);
+        if (dcatView != null) {
+            statements.addAll(dcatView.getStatementsWithBase(prefix));
+        }
+    }
 
-	private List<Statement> addEventStreamStatements(TreeNode treeNode, String baseUrl) {
-		List<Statement> statements = new ArrayList<>();
-		Resource viewId = createResource(baseUrl);
-		statements.addAll(getEventStreamStatements(viewId));
-		statements.addAll(getMemberStatements(treeNode, viewId));
-		return statements;
-	}
+    private List<Statement> addEventStreamStatements(TreeNode treeNode, String baseUrl) {
+        List<Statement> statements = new ArrayList<>();
+        Resource viewId = createResource(baseUrl);
+        statements.addAll(getEventStreamStatements(viewId));
+        statements.addAll(getMemberStatements(treeNode, viewId));
+        return statements;
+    }
 
-	private List<Statement> getMemberStatements(TreeNode treeNode, Resource viewId) {
-		List<Statement> statements = new ArrayList<>();
-		treeNode.getMembers()
-				.stream().map(Member::getMemberIdWithoutPrefix)
-				.forEach(memberId -> statements.add(createStatement(viewId, TREE_MEMBER,
-						createResource(memberId))));
-		return statements;
-	}
+    private List<Statement> getMemberStatements(TreeNode treeNode, Resource viewId) {
+        List<Statement> statements = new ArrayList<>();
+        treeNode.getMembers()
+                .stream().map(Member::getMemberIdWithoutPrefix)
+                .forEach(memberId -> statements.add(createStatement(viewId, TREE_MEMBER,
+                        createResource(memberId))));
+        return statements;
+    }
 
-	private List<Statement> getEventStreamStatements(Resource viewId) {
-		List<Statement> statements = new ArrayList<>();
-		statements.add(createStatement(viewId, RDF_SYNTAX_TYPE, createResource(LDES_EVENT_STREAM_URI)));
-		return statements;
-	}
+    private List<Statement> getEventStreamStatements(Resource viewId) {
+        List<Statement> statements = new ArrayList<>();
+        statements.add(createStatement(viewId, RDF_SYNTAX_TYPE, createResource(LDES_EVENT_STREAM_URI)));
+        return statements;
+    }
 
-	@EventListener
-	public void handleEventStreamInitEvent(EventStreamCreatedEvent event) {
-		eventStreams.put(event.eventStream().getCollection(), event.eventStream());
-	}
+    @EventListener
+    public void handleEventStreamInitEvent(EventStreamCreatedEvent event) {
+        eventStreams.put(event.eventStream().getCollection(), event.eventStream());
+    }
 
-	@EventListener
-	public void handleEventStreamDeletedEvent(EventStreamDeletedEvent event) {
-		eventStreams.remove(event.collectionName());
-	}
+    @EventListener
+    public void handleEventStreamDeletedEvent(EventStreamDeletedEvent event) {
+        eventStreams.remove(event.collectionName());
 
-	@EventListener
-	public void handleShaclInitEvent(ShaclChangedEvent event) {
-		shaclShapes.put(event.getCollection(), event.getModel());
-	}
+        dcatViews.keySet().stream()
+                .filter(viewName -> viewName.getCollectionName().equals(event.collectionName()))
+                .toList()
+                .forEach(dcatViews::remove);
+    }
 
-	@EventListener
-	public void handleShaclDeletedEvent(ShaclDeletedEvent event) {
-		shaclShapes.remove(event.collectionName());
-	}
+    @EventListener
+    public void handleShaclInitEvent(ShaclChangedEvent event) {
+        shaclShapes.put(event.getCollection(), event.getModel());
+    }
 
-	@EventListener
-	public void handleDcatViewSavedEvent(DcatViewSavedEvent event) {
-		dcatViews.put(event.dcatView().getViewName(), event.dcatView());
-	}
+    @EventListener
+    public void handleShaclDeletedEvent(ShaclDeletedEvent event) {
+        shaclShapes.remove(event.collectionName());
+    }
 
-	@EventListener
-	public void handleDcatViewDeletedEvent(DcatViewDeletedEvent event) {
-		dcatViews.remove(event.viewName());
-	}
+    @EventListener
+    public void handleDcatViewSavedEvent(DcatViewSavedEvent event) {
+        dcatViews.put(event.dcatView().getViewName(), event.dcatView());
+    }
+
+    @EventListener
+    public void handleDcatViewDeletedEvent(DcatViewDeletedEvent event) {
+        dcatViews.remove(event.viewName());
+    }
 
 }

--- a/ldes-server-port-fetch-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImplTest.java
+++ b/ldes-server-port-fetch-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImplTest.java
@@ -3,6 +3,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.rest.treenode.services;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.PrefixAdder;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.PrefixAdderImpl;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.*;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.exceptions.MissingResourceException;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.*;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.rest.PrefixConstructor;
 import be.vlaanderen.informatievlaanderen.ldes.server.fetching.entities.Member;
@@ -23,6 +24,7 @@ import static be.vlaanderen.informatievlaanderen.ldes.server.domain.constants.Rd
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TreeNodeConverterImplTest {
 
@@ -195,11 +197,11 @@ class TreeNodeConverterImplTest {
 
     @Test
     void testHandleDcatViewEvents() {
-        TreeNode treeNode = new TreeNode(PREFIX + VIEW_NAME, false, true, List.of(), List.of(),
+        final TreeNode treeNode = new TreeNode(PREFIX + VIEW_NAME, false, true, List.of(), List.of(),
                 COLLECTION_NAME, null);
-        ViewName viewName = new ViewName(COLLECTION_NAME, VIEW_NAME);
-        Model dcat = RDFParser.source("eventstream/streams/dcat-view-valid.ttl").lang(Lang.TURTLE).build().toModel();
-        DcatView dcatView = DcatView.from(viewName, dcat);
+        final ViewName viewName = new ViewName(COLLECTION_NAME, VIEW_NAME);
+        final Model dcat = RDFParser.source("eventstream/streams/dcat-view-valid.ttl").lang(Lang.TURTLE).build().toModel();
+        final DcatView dcatView = DcatView.from(viewName, dcat);
 
         assertThat(treeNodeConverter.toModel(treeNode).size()).isEqualTo(11);
         treeNodeConverter.handleDcatViewSavedEvent(new DcatViewSavedEvent(dcatView));
@@ -210,6 +212,11 @@ class TreeNodeConverterImplTest {
 
     @Test
     void test_HandleEventStreamDeleted() {
+        final TreeNode treeNode = new TreeNode(PREFIX + VIEW_NAME, false, true, List.of(), List.of(),
+                COLLECTION_NAME, null);
 
+        treeNodeConverter.handleEventStreamDeletedEvent(new EventStreamDeletedEvent(COLLECTION_NAME));
+
+        assertThatThrownBy(() -> treeNodeConverter.toModel(treeNode)).isInstanceOf(MissingResourceException.class);
     }
 }

--- a/ldes-server-port-fetch-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImplTest.java
+++ b/ldes-server-port-fetch-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImplTest.java
@@ -207,4 +207,9 @@ class TreeNodeConverterImplTest {
         treeNodeConverter.handleDcatViewDeletedEvent(new DcatViewDeletedEvent(dcatView.getViewName()));
         assertThat(treeNodeConverter.toModel(treeNode).size()).isEqualTo(11);
     }
+
+    @Test
+    void test_HandleEventStreamDeleted() {
+
+    }
 }

--- a/ldes-server-port-fetch-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImplTest.java
+++ b/ldes-server-port-fetch-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/rest/treenode/services/TreeNodeConverterImplTest.java
@@ -2,10 +2,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.rest.treenode.services;
 
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.PrefixAdder;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.converter.PrefixAdderImpl;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.DcatViewDeletedEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.DcatViewSavedEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.EventStreamCreatedEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ShaclChangedEvent;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.*;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.*;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.rest.PrefixConstructor;
 import be.vlaanderen.informatievlaanderen.ldes.server.fetching.entities.Member;

--- a/ldes-server-port-fetch/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/fetching/eventhandler/ViewDeletedHandlerFetch.java
+++ b/ldes-server-port-fetch/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/fetching/eventhandler/ViewDeletedHandlerFetch.java
@@ -15,7 +15,7 @@ public class ViewDeletedHandlerFetch {
 	}
 
 	@EventListener
-	public void handleEventStreamDeletedEvent(ViewDeletedEvent event) {
+	public void handleViewDeletedEvent(ViewDeletedEvent event) {
 		allocationRepository.deleteByCollectionNameAndViewName(event.getViewName().getCollectionName(),
 				event.getViewName().getViewName());
 	}

--- a/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/repositories/ViewCollection.java
+++ b/ldes-server-retention/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/repositories/ViewCollection.java
@@ -1,9 +1,6 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.retention.repositories;
 
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewAddedEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewDeletedEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewInitializationEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewSupplier;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.*;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.ViewSpecification;
 import org.springframework.context.event.EventListener;
@@ -26,6 +23,15 @@ public class ViewCollection {
     @EventListener
     public void handle(ViewDeletedEvent event) {
         views.remove(event.getViewName());
+    }
+
+    @EventListener
+    public void handle(EventStreamDeletedEvent event) {
+        views.keySet().stream()
+                .filter(viewName -> viewName.getCollectionName().equals(event.collectionName()))
+                .toList()
+                .forEach(views::remove);
+
     }
 
     public Collection<ViewSpecification> getViews() {

--- a/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/repositories/ViewCollectionTest.java
+++ b/ldes-server-retention/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/retention/repositories/ViewCollectionTest.java
@@ -1,9 +1,6 @@
 package be.vlaanderen.informatievlaanderen.ldes.server.retention.repositories;
 
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewAddedEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewDeletedEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewInitializationEvent;
-import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.ViewSupplier;
+import be.vlaanderen.informatievlaanderen.ldes.server.domain.events.admin.*;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.ViewName;
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.ViewSpecification;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,10 +49,10 @@ class ViewCollectionTest {
 
     @Test
     void testHandleViewDeletedEvent() {
-        ViewName viewNameA = ViewName.fromString("col/viewA");
-        ViewSpecification viewSpecificationA = new ViewSpecification(viewNameA, List.of(), List.of(), 10);
-        ViewName viewNameB = ViewName.fromString("col/viewB");
-        ViewSpecification viewSpecificationB = new ViewSpecification(viewNameB, List.of(), List.of(), 10);
+        final ViewName viewNameA = ViewName.fromString("col/viewA");
+        final ViewSpecification viewSpecificationA = new ViewSpecification(viewNameA, List.of(), List.of(), 10);
+        final ViewName viewNameB = ViewName.fromString("col/viewB");
+        final ViewSpecification viewSpecificationB = new ViewSpecification(viewNameB, List.of(), List.of(), 10);
 
         viewCollection.handle(new ViewAddedEvent(viewSpecificationA));
         viewCollection.handle(new ViewAddedEvent(viewSpecificationB));
@@ -66,6 +63,28 @@ class ViewCollectionTest {
 
         assertThat(viewCollection.getViews()).hasSize(1);
         assertThat(viewCollection.getViews()).contains(viewSpecificationB);
+    }
+
+    @Test
+    void testHandleEventStreamDeletedEvent() {
+        final String collectionNameA = "colA";
+        final ViewName viewNameAA = new ViewName(collectionNameA, "viewA");
+        final ViewSpecification viewSpecificationA = new ViewSpecification(viewNameAA, List.of(), List.of(), 10);
+        final ViewName viewNameAB = new ViewName(collectionNameA, "viewB");
+        final ViewSpecification viewSpecificationB = new ViewSpecification(viewNameAB, List.of(), List.of(), 10);
+        final ViewName viewNameBC = ViewName.fromString("colB/viewC");
+        final ViewSpecification viewSpecificationC = new ViewSpecification(viewNameBC, List.of(), List.of(), 10);
+
+        viewCollection.handle(new ViewAddedEvent(viewSpecificationA));
+        viewCollection.handle(new ViewAddedEvent(viewSpecificationB));
+        viewCollection.handle(new ViewAddedEvent(viewSpecificationC));
+
+        assertThat(viewCollection.getViews()).hasSize(3);
+
+        viewCollection.handle(new EventStreamDeletedEvent(collectionNameA));
+
+        assertThat(viewCollection.getViews()).hasSize(1);
+        assertThat(viewCollection.getViews()).contains(viewSpecificationC);
     }
 
 }


### PR DESCRIPTION
Before this fix, when an event stream was deleted, both the EventStreamDeletedEvent and ViewDeletedEvent were sent out, resulting that at some places in the code, both events were received and executed some logic twice