### PR TITLE
fix: actuator uses internal addresses

### DIFF
--- a/ldes-server-application/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/config/ActuatorHostNameCustomizer.java
+++ b/ldes-server-application/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/config/ActuatorHostNameCustomizer.java
@@ -1,0 +1,31 @@
+package be.vlaanderen.informatievlaanderen.ldes.server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.ConfigurableWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+import java.net.*;
+
+import static be.vlaanderen.informatievlaanderen.ldes.server.domain.constants.ServerConfig.HOST_NAME_KEY;
+
+@Configuration
+public class ActuatorHostNameCustomizer implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
+    private final String hostName;
+
+    public ActuatorHostNameCustomizer(@Value(HOST_NAME_KEY) String hostName) {
+        this.hostName = hostName;
+    }
+
+    @Override
+    public void customize(ConfigurableWebServerFactory factory) {
+        try {
+            final URL url = URI.create(hostName).toURL();
+            final InetAddress address = InetAddress.getByName(url.getHost());
+            factory.setAddress(address);
+        } catch (UnknownHostException | MalformedURLException e) {
+            throw new IllegalArgumentException("ldes-server.host-name is invalid", e);
+        }
+    }
+
+}

--- a/ldes-server-application/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/config/ActuatorHostNameCustomizer.java
+++ b/ldes-server-application/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/config/ActuatorHostNameCustomizer.java
@@ -7,10 +7,9 @@ import org.springframework.context.annotation.Configuration;
 
 import java.net.*;
 
-import static be.vlaanderen.informatievlaanderen.ldes.server.domain.constants.ServerConfig.HOST_NAME_KEY;
-
 @Configuration
 public class ActuatorHostNameCustomizer implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
+    private static final String HOST_NAME_KEY = "${ldes-server.host-name}";
     private final String hostName;
 
     public ActuatorHostNameCustomizer(@Value(HOST_NAME_KEY) String hostName) {


### PR DESCRIPTION
In https://github.com/Informatievlaanderen/VSDS-LDESServer4J/issues/1029, it was described that the actuator uses the internal addresses, which makes sense, as Spring Boot uses this internal address everywhere. This has now been fixed, where the property `ldes-server.host-name` is used to bind the internal address to this, which replaces the functionality of the already existing property `server.address`. 
This change comes with the precaution that the application will not startup when the server cannot be bound to `ldes-server.host-name`.