### PR TITLE
fix: mongock order failure

### DIFF
--- a/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/config/MongockRunnerExecutor.java
+++ b/ldes-server-infra-mongo/mongock-changesets/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/infra/mongo/mongock/config/MongockRunnerExecutor.java
@@ -3,6 +3,7 @@ package be.vlaanderen.informatievlaanderen.ldes.server.infra.mongo.mongock.confi
 import io.mongock.runner.core.executor.MongockRunner;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,6 +16,7 @@ public class MongockRunnerExecutor {
 	}
 
 	@EventListener(ApplicationReadyEvent.class)
+	@Order(1)
 	public void execute() {
 		if (applicationRunner.isEnabled()) {
 			applicationRunner.execute();


### PR DESCRIPTION
There are multiple event listeners present that listens to the `ApplicationReadyEvent`, not only including the `mongock` module, but also components that keep event streams in memory. When the project was ran by IntelliJ, no error was detected, however, an error occured every time when the project was ran via the Docker image. After looking into the code, there was no order specified which event listeners was executed first. The mongock module must have been detected every time earlier then the rest of the event listeners, but that was not the case in the Docker image, resulting in fetching entities from the db that yet have been updated causing an error. This should be resolved by adding one simple annotation