### PR TITLE
doc: change of metrics URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ mvn clean verify -Dunittestskip=true
 Additionally, it is possible to keep track of metrics and tracings of the LDES Server.
 This will be done through a Zipkin exporter for traces and a Prometheus endpoint for Metrics.
 
-The exposed metrics can be found at `/actuator/metrics`.
+The exposed metrics can be found at `/actuator/prometheus`.
 
 Both traces and metrics are based
 on [OpenTelemetry standard](https://opentelemetry.io/docs/concepts/what-is-opentelemetry/)


### PR DESCRIPTION
Changed metrics url from "/actuator/metrics" to "/actuator/prometheus"