### PR TITLE
fix: lenient version ingest

### DIFF
--- a/ldes-server-ingest/ldes-server-ingest-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/validators/ingestreportvalidator/PathsValidator.java
+++ b/ldes-server-ingest/ldes-server-ingest-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/validators/ingestreportvalidator/PathsValidator.java
@@ -20,16 +20,9 @@ public class PathsValidator implements IngestReportValidator {
 
 	@Override
 	public void validate(Model model, EventStream eventStream, ShaclReportManager reportManager) {
-		List<Resource> memberSubjects = model.listSubjectsWithProperty(createProperty(eventStream.getVersionOfPath()))
+		List<Resource> memberSubjects = model.listSubjects()
 				.filterDrop(RDFNode::isAnon)
 				.toList();
-
-		if (memberSubjects.size() > 1 && !eventStream.isVersionCreationEnabled()) {
-			memberSubjects.forEach(subject -> reportManager.addEntry(subject,
-							"Only 1 member is allowed per request on collection with version creation disabled"
-					)
-			);
-		}
 
 		validateTimestampPath(memberSubjects, model, eventStream, reportManager);
 		validateVersionOfPath(memberSubjects, model, eventStream, reportManager);

--- a/ldes-server-ingest/ldes-server-ingest-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/validators/ingestreportvalidator/PathsValidator.java
+++ b/ldes-server-ingest/ldes-server-ingest-common/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/validators/ingestreportvalidator/PathsValidator.java
@@ -3,73 +3,80 @@ package be.vlaanderen.informatievlaanderen.ldes.server.ingest.validators.ingestr
 import be.vlaanderen.informatievlaanderen.ldes.server.domain.model.EventStream;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
-import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+
 @Order(2)
 @Component
 public class PathsValidator implements IngestReportValidator {
 
-    @Override
-    public void validate(Model model, EventStream eventStream, ShaclReportManager reportManager) {
-        List<Resource> memberSubjects = model.listSubjects().filterDrop(RDFNode::isAnon).toList();
+	@Override
+	public void validate(Model model, EventStream eventStream, ShaclReportManager reportManager) {
+		List<Resource> memberSubjects = model.listSubjectsWithProperty(createProperty(eventStream.getVersionOfPath()))
+				.filterDrop(RDFNode::isAnon)
+				.toList();
 
-        if (memberSubjects.size() > 1 && !eventStream.isVersionCreationEnabled()) {
-            memberSubjects.forEach(subject -> reportManager.addEntry(subject,
-                            "Only 1 member is allowed per request on collection with version creation disabled"
-                    )
-            );
-        }
+		if (memberSubjects.size() > 1 && !eventStream.isVersionCreationEnabled()) {
+			memberSubjects.forEach(subject -> reportManager.addEntry(subject,
+							"Only 1 member is allowed per request on collection with version creation disabled"
+					)
+			);
+		}
 
-        validateTimestampPath(memberSubjects, model, eventStream, reportManager);
-        validateVersionOfPath(memberSubjects, model, eventStream, reportManager);
-    }
+		validateTimestampPath(memberSubjects, model, eventStream, reportManager);
+		validateVersionOfPath(memberSubjects, model, eventStream, reportManager);
+	}
 
-    private void validateTimestampPath(List<Resource> memberSubjects, Model model, EventStream eventStream, ShaclReportManager reportManager) {
-        int expectedNumber = eventStream.isVersionCreationEnabled() ? 0 : 1;
-        List<RDFDatatype> validTypes = List.of(XSDDatatype.XSDdateTime, XSDDatatype.XSDstring);
-        memberSubjects.forEach(subject -> {
-            List<Statement> timestampStatements = getStatementsOfPath(subject, model, eventStream.getTimestampPath());
-            if (timestampStatements.size() != expectedNumber) {
-                reportManager.addEntry(subject,
-                        String.format(String.format("Member must have exactly %s statement%s with timestamp path: %s as predicate.", expectedNumber, expectedNumber == 1 ? "" : "s", eventStream.getTimestampPath()))
-                );
-            }
+	private void validateTimestampPath(List<Resource> memberSubjects, Model model, EventStream eventStream, ShaclReportManager reportManager) {
+		int expectedNumber = eventStream.isVersionCreationEnabled() ? 0 : 1;
+		List<RDFDatatype> validTypes = List.of(XSDDatatype.XSDdateTime, XSDDatatype.XSDstring);
+		memberSubjects.forEach(subject -> {
+			List<Statement> timestampStatements = getStatementsOfPath(subject, model, eventStream.getTimestampPath());
+			if (timestampStatements.size() != expectedNumber) {
+				reportManager.addEntry(subject,
+						String.format(String.format("Member must have exactly %s statement%s with timestamp path: %s as predicate.", expectedNumber, expectedNumber == 1 ? "" : "s", eventStream.getTimestampPath()))
+				);
+			}
 
-            timestampStatements.forEach(statement -> {
-                if (!statement.getObject().isLiteral() || !validTypes.contains(statement.getLiteral().getDatatype())) {
-                    reportManager.addEntry(subject,
-                            String.format(String.format("Object of statement with predicate: %s should be a literal either of type %s or %s", eventStream.getTimestampPath(), XSDDatatype.XSDdateTime.getURI(), XSDDatatype.XSDstring.getURI()))
-                    );
-                }
-            });
-        });
-    }
+			timestampStatements.forEach(statement -> {
+				if (!statement.getObject().isLiteral() || !validTypes.contains(statement.getLiteral().getDatatype())) {
+					reportManager.addEntry(subject,
+							String.format(String.format("Object of statement with predicate: %s should be a literal either of type %s or %s", eventStream.getTimestampPath(), XSDDatatype.XSDdateTime.getURI(), XSDDatatype.XSDstring.getURI()))
+					);
+				}
+			});
+		});
+	}
 
-    private void validateVersionOfPath(List<Resource> memberSubjects, Model model, EventStream eventStream, ShaclReportManager reportManager) {
-        int expectedNumber = eventStream.isVersionCreationEnabled() ? 0 : 1;
-        memberSubjects.forEach(subject -> {
-            List<Statement> versionOfStatements = getStatementsOfPath(subject, model, eventStream.getVersionOfPath());
-            if (versionOfStatements.size() != expectedNumber) {
-                reportManager.addEntry(subject,
-                        String.format("Member must have exactly %s statement%s with versionOf path: %s as predicate.", expectedNumber, expectedNumber == 1 ? "" : "s", eventStream.getVersionOfPath())
-                );
-            }
+	private void validateVersionOfPath(List<Resource> memberSubjects, Model model, EventStream eventStream, ShaclReportManager reportManager) {
+		int expectedNumber = eventStream.isVersionCreationEnabled() ? 0 : 1;
+		memberSubjects.forEach(subject -> {
+			List<Statement> versionOfStatements = getStatementsOfPath(subject, model, eventStream.getVersionOfPath());
+			if (versionOfStatements.size() != expectedNumber) {
+				reportManager.addEntry(subject,
+						String.format("Member must have exactly %s statement%s with versionOf path: %s as predicate.", expectedNumber, expectedNumber == 1 ? "" : "s", eventStream.getVersionOfPath())
+				);
+			}
 
-            versionOfStatements.forEach(statement -> {
-                if (!statement.getObject().isResource()) {
-                    reportManager.addEntry(subject,
-                            String.format("Object of statement with predicate: %s should be a resource", eventStream.getVersionOfPath())
-                    );
-                }
-            });
-        });
-    }
+			versionOfStatements.forEach(statement -> {
+				if (!statement.getObject().isResource()) {
+					reportManager.addEntry(subject,
+							String.format("Object of statement with predicate: %s should be a resource", eventStream.getVersionOfPath())
+					);
+				}
+			});
+		});
+	}
 
-    private List<Statement> getStatementsOfPath(Resource memberSubject, Model model, String path) {
-        return model.listStatements(memberSubject, ResourceFactory.createProperty(path), (RDFNode) null).toList();
-    }
+	private List<Statement> getStatementsOfPath(Resource memberSubject, Model model, String path) {
+		return model.listStatements(memberSubject, createProperty(path), (RDFNode) null).toList();
+	}
 }

--- a/ldes-server-ingest/ldes-server-ingest-common/src/main/java/module-info.java
+++ b/ldes-server-ingest/ldes-server-ingest-common/src/main/java/module-info.java
@@ -8,7 +8,8 @@ module ldes.ingest.domain {
     requires org.apache.jena.arq;
     requires micrometer.core;
     requires micrometer.observation;
-    exports be.vlaanderen.informatievlaanderen.ldes.server.ingest.entities;
+	requires spring.core;
+	exports be.vlaanderen.informatievlaanderen.ldes.server.ingest.entities;
     exports be.vlaanderen.informatievlaanderen.ldes.server.ingest.repositories;
     exports be.vlaanderen.informatievlaanderen.ldes.server.ingest;
 }

--- a/ldes-server-ingest/ldes-server-ingest-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/rest/MemberIngestControllerTest.java
+++ b/ldes-server-ingest/ldes-server-ingest-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/rest/MemberIngestControllerTest.java
@@ -103,7 +103,8 @@ class MemberIngestControllerTest {
                         .content(ldesMemberBytes))
                 .andExpect(status().isBadRequest())
 		        .andExpect(header().exists("X-App-Version"))
-		        .andExpect(content().string(containsString("Only 1 member is allowed per request on collection with version creation disabled")));
+		        .andExpect(content().string(containsString("Member must have exactly 1 statement with versionOf path")))
+		        .andExpect(content().string(containsString("Member must have exactly 1 statement with timestamp path")));
     }
 
     @Test

--- a/ldes-server-ingest/ldes-server-ingest-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/rest/validators/memberingestvalidator/MemberIngestValidatorTest.java
+++ b/ldes-server-ingest/ldes-server-ingest-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/rest/validators/memberingestvalidator/MemberIngestValidatorTest.java
@@ -109,8 +109,6 @@ class MemberIngestValidatorTest {
                             List.of("Member must have exactly 1 statement with timestamp path: " + TIMESTAMP_PATH)),
                     Arguments.of("example-ldes-member-multiple-version-ofs.nq", VERSION,
                             List.of("Member must have exactly 1 statement with versionOf path: " + VERSIONOF_PATH)),
-                    Arguments.of("example-ldes-member-without-version-of.nq", VERSION,
-                            List.of("Member must have exactly 1 statement with versionOf path: " + VERSIONOF_PATH)),
                     Arguments.of("example-ldes-member-wrong-type-version-of.nq", VERSION,
                             List.of("Object of statement with predicate: " + VERSIONOF_PATH + " should be a resource")),
                     Arguments.of("example-ldes-member-wrong-type-timestamp.nq", VERSION,
@@ -128,7 +126,8 @@ class MemberIngestValidatorTest {
                     Arguments.of(RDFDataMgr.loadModel("example-ldes-member-state.nq"), STATE),
                     Arguments.of(RDFDataMgr.loadModel("example-ldes-member-typeless-time.nq"), VERSION),
                     Arguments.of(RDFDataMgr.loadModel("example-ldes-member-string-time.nq"), VERSION),
-                    Arguments.of(RDFDataMgr.loadModel("example-ldes-member.nq"), VERSION)
+                    Arguments.of(RDFDataMgr.loadModel("example-ldes-member.nq"), VERSION),
+                    Arguments.of(RDFDataMgr.loadModel("example-ldes-member-without-version-of.nq"), VERSION)
             );
         }
     }

--- a/ldes-server-ingest/ldes-server-ingest-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/rest/validators/memberingestvalidator/MemberIngestValidatorTest.java
+++ b/ldes-server-ingest/ldes-server-ingest-rest/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/rest/validators/memberingestvalidator/MemberIngestValidatorTest.java
@@ -111,6 +111,8 @@ class MemberIngestValidatorTest {
                             List.of("Member must have exactly 1 statement with versionOf path: " + VERSIONOF_PATH)),
                     Arguments.of("example-ldes-member-wrong-type-version-of.nq", VERSION,
                             List.of("Object of statement with predicate: " + VERSIONOF_PATH + " should be a resource")),
+                    Arguments.of("example-ldes-member-without-version-of.nq", VERSION,
+                            List.of("Member must have exactly 1 statement with versionOf path: " + VERSIONOF_PATH)),
                     Arguments.of("example-ldes-member-wrong-type-timestamp.nq", VERSION,
                             List.of("Object of statement with predicate: " + TIMESTAMP_PATH + " should be a literal either of type " + XSDDatatype.XSDdateTime.getURI() + " or " + XSDDatatype.XSDstring.getURI())),
                     Arguments.of("example-ldes-member-dangling-nodes.nq", VERSION, List.of("Object graphs don't allow blank nodes to occur outside of a named object.")),
@@ -126,8 +128,7 @@ class MemberIngestValidatorTest {
                     Arguments.of(RDFDataMgr.loadModel("example-ldes-member-state.nq"), STATE),
                     Arguments.of(RDFDataMgr.loadModel("example-ldes-member-typeless-time.nq"), VERSION),
                     Arguments.of(RDFDataMgr.loadModel("example-ldes-member-string-time.nq"), VERSION),
-                    Arguments.of(RDFDataMgr.loadModel("example-ldes-member.nq"), VERSION),
-                    Arguments.of(RDFDataMgr.loadModel("example-ldes-member-without-version-of.nq"), VERSION)
+                    Arguments.of(RDFDataMgr.loadModel("example-ldes-member.nq"), VERSION)
             );
         }
     }


### PR DESCRIPTION
This pull request includes several changes to the `ldes-server-ingest` module, primarily focusing on improving validation logic and updating dependencies. The most important changes include modifications to the `PathsValidator` class, updates to the module dependencies, and adjustments to the test cases in `MemberIngestValidatorTest`.

### Validation Logic Improvements:
* [`PathsValidator.java`](diffhunk://#diff-063006619271fcae86f7156df39bddf8241e3d1a8f00eccc22bf469b879803d8L6-R25): Modified the `validate` method to use `listSubjectsWithProperty` instead of `listSubjects`, enhancing the logic for filtering subjects based on the `eventStream` version path.
* [`PathsValidator.java`](diffhunk://#diff-063006619271fcae86f7156df39bddf8241e3d1a8f00eccc22bf469b879803d8L73-R80): Updated the `getStatementsOfPath` method to use `createProperty` for creating RDF properties, ensuring consistency with the changes in the `validate` method.

### Dependency Updates:
* [`module-info.java`](diffhunk://#diff-2520617707617db7c14a04bc85cb2ecd8383af753bec32ec00c92402d12058a3R11): Added `spring.core` as a required module to support Spring framework annotations used in the project.

### Test Case Adjustments:
* [`MemberIngestValidatorTest.java`](diffhunk://#diff-50a74f4caff9c9a64b42fba7a9211c8c737fe184d3d901a7e27aeea9a2edd8b4L112-L113): Removed and re-added test cases to ensure the correct validation of members with and without the `versionOf` path, improving test coverage and accuracy. [[1]](diffhunk://#diff-50a74f4caff9c9a64b42fba7a9211c8c737fe184d3d901a7e27aeea9a2edd8b4L112-L113) [[2]](diffhunk://#diff-50a74f4caff9c9a64b42fba7a9211c8c737fe184d3d901a7e27aeea9a2edd8b4L131-R130)