### PR TITLE
fix: missing members when ingesting multi-threaded

### DIFF
--- a/ldes-server-infra-postgres/postgres-ingest-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/postgres/MemberPostgresRepository.java
+++ b/ldes-server-infra-postgres/postgres-ingest-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/ingest/postgres/MemberPostgresRepository.java
@@ -53,6 +53,10 @@ public class MemberPostgresRepository implements MemberRepository {
 					})
 					.toList();
 
+			// Note: that we lock the collection row to ensure no interleaved sequence numbers are assigned to the member_id
+			// Note: that the lock is released when txn is committed (upon method exit as it is transactional)
+			jdbcTemplate.queryForObject("SELECT name FROM collections WHERE collection_id = ? FOR UPDATE", String.class, collectionId);
+
 			jdbcTemplate.batchUpdate(INSERT_SQL, batchArgs);
 
 			updateCollectionStats(members.size(), collectionId);


### PR DESCRIPTION
fix: lock collection row to prevent interleaved sequence numbers in member_id when ingesting members