### PR TITLE
chore: dcat catalog repository: remove unreachable logic

### DIFF
--- a/ldes-server-infra-postgres/postgres-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/postgres/dcatserver/DcatCatalogPostgresRepository.java
+++ b/ldes-server-infra-postgres/postgres-admin-repository/src/main/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/postgres/dcatserver/DcatCatalogPostgresRepository.java
@@ -43,11 +43,9 @@ public class DcatCatalogPostgresRepository implements DcatServerRepository {
 
 	@Override
 	public Optional<DcatServer> findSingleDcatServer() {
-		List<DcatServer> servers = repository.findAll().stream().map(converter::toDcatServer).toList();
-		if (servers.size() > 1) {
-			throw new IllegalStateException("Multiple dcatServers found. There should be 0 or 1 record of this.");
-		}
-
-		return servers.isEmpty() ? Optional.empty() : Optional.of(servers.get(0));
+		return repository.findAll()
+				.stream()
+				.map(converter::toDcatServer)
+				.findFirst();
 	}
 }

--- a/ldes-server-infra-postgres/postgres-admin-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/postgres/dcatserver/DcatServerPostgresRepositoryTest.java
+++ b/ldes-server-infra-postgres/postgres-admin-repository/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/admin/postgres/dcatserver/DcatServerPostgresRepositoryTest.java
@@ -15,7 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -95,16 +96,6 @@ class DcatServerPostgresRepositoryTest {
 
 	@Nested
 	class FindSingleDcatServer {
-
-		@Test
-		void should_ThrowException_when_MoreThanOneResultFound() {
-			List<DcatCatalogEntity> entities = List.of(
-					new DcatCatalogEntity("id1", ""),
-					new DcatCatalogEntity("id2", ""));
-			when(dcatCatalogEntityRepository.findAll()).thenReturn(entities);
-
-			assertThrows(IllegalStateException.class, () -> dcatServerRepository.findSingleDcatServer());
-		}
 
 		@Test
 		void should_ReturnEmpty_when_NoResultsFound() {

--- a/ldes-server-integration-test/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/FragmentationSteps.java
+++ b/ldes-server-integration-test/src/test/java/be/vlaanderen/informatievlaanderen/ldes/server/FragmentationSteps.java
@@ -60,7 +60,7 @@ public class FragmentationSteps extends LdesServerIntegrationTest {
 
 	@And("I fetch the next fragment through the first {string}")
 	public void iFetchTheNextFragmentThroughTheFirst(String relation) {
-		await().atMost(60, TimeUnit.SECONDS)
+		await().atMost(90, TimeUnit.SECONDS)
 				.untilAsserted(() -> {
 					fetchFragment(currentPath);
 					assertNotNull(currentFragment);


### PR DESCRIPTION
Cleanup of Dcat catalog repo [1284](https://github.com/Informatievlaanderen/VSDS-LDESServer4J/issues/1284)